### PR TITLE
ACA-1303: Fix description link in provision_vm role README file

### DIFF
--- a/roles/provision_vm/README.md
+++ b/roles/provision_vm/README.md
@@ -406,7 +406,7 @@ N/A
     Set the guest ID.
     This parameter is case sensitive.
     This field is required when creating a virtual machine, not required when creating from the template.
-    Valid values are referenced here: https://code.vmware.com/apis/358/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html
+    Valid values are referenced [here](https://vdc-download.vmware.com/vmwb-repository/dcr-public/184bb3ba-6fa8-4574-a767-d0c96e2a38f4/ba9422ef-405c-47dd-8553-e11b619185b2/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html).
 
 - **provision_vm_hardware** (dictionary):
     Manage virtual machine's hardware attributes.
@@ -556,7 +556,7 @@ N/A
 
 - **provision_vm_vapp_properties** (list):
     A list of vApp properties.
-    For full list of attributes and types refer to: https://code.vmware.com/apis/704/vsphere/vim.vApp.PropertyInfo.html
+    For full list of attributes and types refer to [vApp Properties info](https://vdc-download.vmware.com/vmwb-repository/dcr-public/184bb3ba-6fa8-4574-a767-d0c96e2a38f4/ba9422ef-405c-47dd-8553-e11b619185b2/SDK/vsphere-ws/docs/ReferenceGuide/vim.vApp.PropertyInfo.html)
     Element keys:
     * id:
       type: str

--- a/tests/integration/targets/prepare_soap/tasks/main.yml
+++ b/tests/integration/targets/prepare_soap/tasks/main.yml
@@ -9,10 +9,7 @@
   containers.podman.podman_container:
     name: vmwaresoap
 
-    # image: docker.io/vmware/vcsim:latest
-    # due to an issue https://github.com/vmware/govmomi/issues/3337 -
-    # vcsim: vim.VirtualMachine.snapshot property causes runtime error when not set
-    image: quay.io/bardielle/vcsim:fix_vm
+    image: docker.io/vmware/vcsim:latest
     state: started
     recreate: yes
     expose:


### PR DESCRIPTION
Updated the provision_vm_guest_id description to point to vSphere 7.0 