### PR TITLE
add provision_virtual_esxi

### DIFF
--- a/changelogs/fragments/20__mm-feature__add-provision-virtual-esxi.yml
+++ b/changelogs/fragments/20__mm-feature__add-provision-virtual-esxi.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - provision_virtual_esxi - Added new role for provisioning a VM and installing ESXi on it. Added integration tests for role

--- a/changelogs/fragments/mm-feature__add-provision-virtual-esxi.yml
+++ b/changelogs/fragments/mm-feature__add-provision-virtual-esxi.yml
@@ -1,6 +1,0 @@
----
-minor_changes:
-  - added role provision_virtual_esxi
-
-trivial:
-  - added integration tests for role provision_virtual_esxi

--- a/changelogs/fragments/mm-feature__add-provision-virtual-esxi.yml
+++ b/changelogs/fragments/mm-feature__add-provision-virtual-esxi.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - added role provision_virtual_esxi
+
+trivial:
+  - added integration tests for role provision_virtual_esxi

--- a/roles/provision_virtual_esxi/README.md
+++ b/roles/provision_virtual_esxi/README.md
@@ -1,0 +1,113 @@
+# provision_virtual_esxi
+
+Provision one or more virtual ESXi hosts
+
+## Requirements
+
+pyvomi
+
+## Role Variables
+
+### Auth
+- **provision_virtual_esxi_username**:
+  - str, The username to use to authenticate to the esxi or vcenter on which you want to deploy the vm. Required.
+
+- **provision_virtual_esxi_password**:
+  - str, The password to use to authenticate to the esxi or vcenter on which you want to deploy the vm. Required.
+
+- **provision_virtual_esxi_validate_certs**:
+  - bool, If true then certificates will be validated when connecting to the esxi or vcenter for auth. Optional.
+
+- **provision_virtual_esxi_port**:
+  - int, The port to use when connecting to the esxi or vcenter for auth. Optional.
+
+### Placement
+- **provision_virtual_esxi_cluster**:
+  - str, The name of the cluster in which you want to deploy the new vms.
+
+- **provision_virtual_esxi_datacenter**:
+  - str, The name of the datacenter in which you want to deploy the new vms.
+
+- **provision_virtual_esxi_resource_pool**:
+  - str, The name of the resource pool in which to place the VMs. Its recommended to use a resource pool and limit the amount of resources these ESXi hosts can use
+
+- **provision_virtual_esxi_folder**:
+  - str, The name of the folder in which to place the VMs
+
+
+### VM Options
+- **provision_virtual_esxi_vms**:
+  - list(dict), A list of dictionaries describing the esxi hosts you want to manage. If no VM exists with the name, a new VM will be created. VMs are created in booted to save time.
+  - **Members**
+    - name - str, The name of the VM that you want to manage. Required
+    - networks - list(dict), The network definition specific to this VM. If undefined, the value from `provision_virtual_esxi_networks` is used.
+    - disks - list(dict), The disk definition specific to this VM. If undefined, the value from `provision_virtual_esxi_disks` is used.
+    - memory_mb - int, The memory definition specific to this VM. If undefined, the value from `provision_virtual_esxi_memory_mb` is used.
+    - cpus - int, The cpu definition specific to this VM. If undefined, the value from `provision_virtual_esxi_cpus` is used.
+
+- **provision_virtual_esxi_datastore_iso_path**:
+  - str, The datastore path to the ESXi ISO file that new VMs should use to boot. For example, a file in the folder ISO on datastore1 might have the path `[datastore1] ISO\my_esxi_8.iso`
+
+- **provision_virtual_esxi_networks**:
+  - list(dict), A list of dictionaries describing the network device configs for this VM. Required. You may need to enable promiscuous mode and allow forged transmits on the upstream port group/vSwitch to have a working network downstream. See https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_module.html#parameter-networks
+  - Default is a DHCP vmxnet3 NIC on 'VM Network'
+
+- **provision_virtual_esxi_disks**:
+  - list(dict), A list of dictionaries describing the disk device configs for this VM. See https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_module.html#parameter-disk
+  - Default is a thin provisioned 100 GB disk
+
+- **provision_virtual_esxi_memory_mb**:
+  - int, The amount of memory to assign to this VM.
+  - Default is 18000
+
+- **provision_virtual_esxi_cpus**:
+  - int, The number of vCPUs to assign to this VM.
+  - Default is 4
+
+## Dependencies
+
+- NA
+
+## Example Playbook
+```yaml
+---
+# In the playbook below, 3 ESXi hosts are created
+# The first uses the role defaults for hardware
+# The second has extra disks assigned to it
+# The third has extra memory and CPUs
+- name: Provision ESXi Hosts
+  hosts: localhost
+  roles:
+    - role: cloud.vmware_ops.provision_virtual_esxi
+      vars:
+        provision_virtual_esxi_hostname: "{{ vcenter_hostname }}"
+        provision_virtual_esxi_username: "{{ vcenter_username }}"
+        provision_virtual_esxi_password: "{{ vcenter_password }}"
+        provision_virtual_esxi_folder: ""
+        provision_virtual_esxi_vms:
+          - name: esxi-1
+          - name: esxi-2
+            disks:
+              - size_gb: 300
+                type: thin
+                autoselect_datastore: true
+              - size_gb: 300
+                type: thin
+                autoselect_datastore: true
+          - name: esxi-3
+            memory_mb: 24000
+            cpus: 12
+        provision_virtual_esxi_iso_path: "[nfs-datastore-iso] esxi_8.iso"
+```
+
+License
+-------
+
+GNU General Public License v3.0 or later
+
+See [LICENCE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
+
+Author Information
+------------------
+
+- Ansible Cloud Content Team

--- a/roles/provision_virtual_esxi/defaults/main.yml
+++ b/roles/provision_virtual_esxi/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# hardware defaults are chosen based on the minimum requirements to run vcenter,
+# plus a little bit extra for the ESXI system
+# https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-vcenter-upgrade/GUID-752FCA83-1A9B-499E-9C65-D5625351C0B5.html
 provision_virtual_esxi_memory_mb: 18000
 provision_virtual_esxi_cpus: 4
 provision_virtual_esxi_disks:

--- a/roles/provision_virtual_esxi/defaults/main.yml
+++ b/roles/provision_virtual_esxi/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+provision_virtual_esxi_memory_mb: 18000
+provision_virtual_esxi_cpus: 4
+provision_virtual_esxi_disks:
+  - size_gb: 100
+    type: thin
+    autoselect_datastore: true
+provision_virtual_esxi_networks:
+  - name: VM Network
+    device_type: vmxnet3
+    type: dhcp
+provision_virtual_esxi_boot_firmware: bios

--- a/roles/provision_virtual_esxi/tasks/deploy_new_esxi_hosts.yml
+++ b/roles/provision_virtual_esxi/tasks/deploy_new_esxi_hosts.yml
@@ -1,0 +1,77 @@
+---
+- name: Deploy ESXi Hosts
+  ansible.builtin.include_role:
+    name: cloud.vmware_ops.provision_vm
+  vars:
+    provision_vm_hostname: "{{ provision_virtual_esxi_hostname }}"
+    provision_vm_username: "{{ provision_virtual_esxi_username }}"
+    provision_vm_password: "{{ provision_virtual_esxi_password }}"
+    provision_vm_validate_certs: "{{ provision_virtual_esxi_validate_certs | default(omit) }}"
+    provision_vm_port: "{{ provision_virtual_esxi_port | default(omit) }}"
+    provision_vm_cluster: "{{ provision_virtual_esxi_cluster | default(omit) }}"
+    provision_vm_datacenter: "{{ provision_virtual_esxi_datacenter | default(omit) }}"
+    provision_vm_folder: "{{ provision_virtual_esxi_folder | default(omit) }}"
+    provision_vm_resource_pool: "{{ provision_virtual_esxi_resource_pool | default(omit) }}"
+    provision_vm_cdrom:
+      - controller_number: 0
+        unit_number: 0
+        state: present
+        type: iso
+        iso_path: "{{ provision_virtual_esxi_datastore_iso_path }}"
+    provision_vm_name: "{{ _result._esxi.name }}"
+    provision_vm_guest_id: vmkernel8Guest
+    provision_vm_state: present
+    provision_vm_networks: "{{ _esxi.networks | default(provision_virtual_esxi_networks) }}"
+    provision_vm_disk: "{{ _esxi.disks | default(provision_virtual_esxi_disks) }}"
+    provision_vm_hardware:
+      memory_mb: "{{ _esxi.memory_mb | default(provision_virtual_esxi_memory_mb) }}"
+      num_cpus: "{{ _esxi.cpus | default(provision_virtual_esxi_cpus) }}"
+      boot_firmware: "{{ provision_virtual_esxi_boot_firmware }}"
+      nested_virt: true
+  when: _result.instance is not defined or not _result.instance
+  loop: "{{ _esxi_host_check.results }}"
+  loop_control:
+    loop_var: _result
+    label: _result._esxi.name
+
+- name: Power On The New ESXi Hosts
+  ansible.builtin.include_role:
+    name: cloud.vmware_ops.provision_vm
+  vars:
+    provision_vm_hostname: "{{ provision_virtual_esxi_hostname }}"
+    provision_vm_username: "{{ provision_virtual_esxi_username }}"
+    provision_vm_password: "{{ provision_virtual_esxi_password }}"
+    provision_vm_validate_certs: "{{ provision_virtual_esxi_validate_certs | default(omit) }}"
+    provision_vm_port: "{{ provision_virtual_esxi_port | default(omit) }}"
+    provision_vm_cluster: "{{ provision_virtual_esxi_cluster | default(omit) }}"
+    provision_vm_datacenter: "{{ provision_virtual_esxi_datacenter | default(omit) }}"
+    provision_vm_folder: "{{ provision_virtual_esxi_folder | default(omit) }}"
+    provision_vm_name: "{{ _result._esxi.name }}"
+    provision_vm_state: poweredon
+  when: _result.instance is not defined or not _result.instance
+  loop: "{{ _esxi_host_check.results }}"
+  loop_control:
+    loop_var: _result
+    label: _result._esxi.name
+
+- name: Wait for New ESXi Deployment
+  community.vmware.vmware_guest_info:
+    hostname: "{{ provision_virtual_esxi_hostname }}"
+    username: "{{ provision_virtual_esxi_username }}"
+    password: "{{ provision_virtual_esxi_password }}"
+    datacenter: "{{ provision_virtual_esxi_datacenter | default('') }}"
+    port: "{{ provision_virtual_esxi_port | default(omit) }}"
+    validate_certs: "{{ provision_virtual_esxi_validate_certs | default(omit) }}"
+    name: "{{ _result._esxi.name }}"
+  when: _result.instance is not defined or not _result.instance
+  loop: "{{ _esxi_host_check.results }}"
+  loop_control:
+    loop_var: _result
+    label: _result._esxi.name
+  register: _new_esxi_info
+  until: >-
+    _new_esxi_info.instance is defined and
+    (_new_esxi_info.instance.hw_power_status == 'poweredOff' or
+    _new_esxi_info.instance.ipv4 or _new_esxi_info.instance.ipv6)
+  retries: 30
+  delay: 15

--- a/roles/provision_virtual_esxi/tasks/main.yml
+++ b/roles/provision_virtual_esxi/tasks/main.yml
@@ -1,0 +1,88 @@
+---
+- name: Check General Mandatory Variables Are Defined
+  ansible.builtin.assert:
+    that:
+      - provision_virtual_esxi_username is defined
+      - provision_virtual_esxi_password is defined
+      - provision_virtual_esxi_hostname is defined
+      - provision_virtual_esxi_vms is defined
+      - not (provision_virtual_esxi_vms | selectattr('name', 'undefined'))
+    quiet: true
+    fail_msg: Variable must be set when using this role.
+
+- name: Check For Missing Hosts
+  community.vmware.vmware_guest_info:
+    hostname: "{{ provision_virtual_esxi_hostname }}"
+    username: "{{ provision_virtual_esxi_username }}"
+    password: "{{ provision_virtual_esxi_password }}"
+    port: "{{ provision_virtual_esxi_port | default(omit) }}"
+    datacenter: "{{ provision_virtual_esxi_datacenter | default('') }}"
+    validate_certs: "{{ provision_virtual_esxi_validate_certs | default(omit) }}"
+    name: "{{ _esxi.name }}"
+  failed_when: false
+  register: _esxi_host_check
+  loop: "{{ provision_virtual_esxi_vms }}"
+  loop_control:
+    loop_var: _esxi
+    label: _esxi.name
+
+- name: Include New ESXi Hosts Tasks
+  when: >-
+    (_esxi_host_check.results | selectattr('instance', 'undefined') is any) or
+    (_esxi_host_check.results | selectattr('instance', 'defined') | map(attribute='instance') is not all)
+  block:
+    - name: Check VM Mandatory Variables Are Defined
+      ansible.builtin.assert:
+        that:
+          - provision_virtual_esxi_iso_path is defined
+        quiet: true
+        fail_msg: Variable must be set when using this role.
+    - name: Deploy New ESXi Hosts
+      ansible.builtin.include_tasks: deploy_new_esxi_hosts.yml
+
+- name: Configure Existing ESXi Hosts
+  ansible.builtin.include_role:
+    name: cloud.vmware_ops.provision_vm
+  vars:
+    provision_vm_hostname: "{{ provision_virtual_esxi_hostname }}"
+    provision_vm_username: "{{ provision_virtual_esxi_username }}"
+    provision_vm_password: "{{ provision_virtual_esxi_password }}"
+    provision_vm_port: "{{ provision_virtual_esxi_port | default(omit) }}"
+    provision_vm_validate_certs: "{{ provision_virtual_esxi_validate_certs | default(omit) }}"
+    provision_vm_cluster: "{{ provision_virtual_esxi_cluster | default(omit) }}"
+    provision_vm_datacenter: "{{ provision_virtual_esxi_datacenter | default(omit) }}"
+    provision_vm_folder: "{{ provision_virtual_esxi_folder | default(omit) }}"
+    provision_vm_resource_pool: "{{ provision_virtual_esxi_resource_pool | default(omit) }}"
+    provision_vm_name: "{{ _esxi.name }}"
+    provision_vm_guest_id: vmkernel8Guest
+    provision_vm_state: present
+    provision_vm_networks: "{{ _esxi.networks | default(provision_virtual_esxi_networks) }}"
+    provision_vm_disk: "{{ _esxi.disks | default(provision_virtual_esxi_disks) }}"
+    provision_vm_hardware:
+      memory_mb: "{{ _esxi.memory_mb | default(provision_virtual_esxi_memory_mb) }}"
+      num_cpus: "{{ _esxi.cpus | default(provision_virtual_esxi_cpus) }}"
+      boot_firmware: "{{ provision_virtual_esxi_boot_firmware }}"
+      nested_virt: true
+  loop: "{{ provision_virtual_esxi_vms }}"
+  loop_control:
+    loop_var: _esxi
+    label: _esxi.name
+
+- name: Power On The ESXi Hosts
+  ansible.builtin.include_role:
+    name: cloud.vmware_ops.provision_vm
+  vars:
+    provision_vm_hostname: "{{ provision_virtual_esxi_hostname }}"
+    provision_vm_username: "{{ provision_virtual_esxi_username }}"
+    provision_vm_password: "{{ provision_virtual_esxi_password }}"
+    provision_vm_port: "{{ provision_virtual_esxi_port | default(omit) }}"
+    provision_vm_validate_certs: "{{ provision_virtual_esxi_validate_certs | default(omit) }}"
+    provision_vm_cluster: "{{ provision_virtual_esxi_cluster | default(omit) }}"
+    provision_vm_datacenter: "{{ provision_virtual_esxi_datacenter | default(omit) }}"
+    provision_vm_folder: "{{ provision_virtual_esxi_folder | default(omit) }}"
+    provision_vm_name: "{{ _esxi.name }}"
+    provision_vm_state: poweredon
+  loop: "{{ provision_virtual_esxi_vms }}"
+  loop_control:
+    loop_var: _esxi
+    label: _esxi.name

--- a/tests/integration/targets/provision_virtual_esxi_test/mock_side_effects.yml
+++ b/tests/integration/targets/provision_virtual_esxi_test/mock_side_effects.yml
@@ -1,0 +1,24 @@
+---
+- hosts: localhost
+  gather_facts: false
+  vars_files:
+    - "{{ playbook_dir }}/vars/main.yml"
+  tasks:
+    # the esxi ISO usually powers down new hosts when they are done
+    - name: Mock ESXi Host Power Down
+      community.vmware.vmware_guest:
+        name: "{{ item }}"
+        folder: "{{ provision_virtual_esxi_folder }}"
+        datacenter: "{{ provision_virtual_esxi_datacenter }}"
+        cluster: "{{ provision_virtual_esxi_cluster }}"
+        state: poweredoff
+        hostname: "{{ provision_virtual_esxi_hostname }}"
+        username: "{{ provision_virtual_esxi_username }}"
+        password: "{{ provision_virtual_esxi_password }}"
+        validate_certs: false
+        port: "{{ provision_virtual_esxi_port }}"
+      loop: "{{ provision_virtual_esxi_vms | map(attribute='name') }}"
+      delay: 15
+      retries: 20
+      register: _res
+      until: _res is changed

--- a/tests/integration/targets/provision_virtual_esxi_test/run.yml
+++ b/tests/integration/targets/provision_virtual_esxi_test/run.yml
@@ -1,0 +1,13 @@
+- hosts: localhost
+  gather_facts: no
+  collections:
+    - community.general
+
+  tasks:
+    - name: Vcsim
+      ansible.builtin.import_role:
+        name: prepare_soap
+
+    - name: Import provision virtual ESXi role
+      ansible.builtin.import_role:
+        name: provision_virtual_esxi_test

--- a/tests/integration/targets/provision_virtual_esxi_test/runme.sh
+++ b/tests/integration/targets/provision_virtual_esxi_test/runme.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+source ../init.sh
+ansible-playbook mock_side_effects.yml  &
+PID="$!"
+
+ansible-playbook run.yml
+RESULT=$?
+pkill -P "$PID"
+
+exit $RESULT

--- a/tests/integration/targets/provision_virtual_esxi_test/tasks/main.yml
+++ b/tests/integration/targets/provision_virtual_esxi_test/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Provision VM
+  ansible.builtin.import_role:
+    name: cloud.vmware_ops.provision_virtual_esxi

--- a/tests/integration/targets/provision_virtual_esxi_test/vars/main.yml
+++ b/tests/integration/targets/provision_virtual_esxi_test/vars/main.yml
@@ -1,0 +1,18 @@
+---
+provision_virtual_esxi_hostname: "127.0.0.1"
+provision_virtual_esxi_username: "test"
+provision_virtual_esxi_password: "test"
+provision_virtual_esxi_validate_certs: false
+provision_virtual_esxi_port: 8989
+provision_virtual_esxi_cluster: "DC0_C0"
+provision_virtual_esxi_folder: "/DC0/vm"
+provision_virtual_esxi_datacenter: "DC0"
+provision_virtual_esxi_iso_path: ""
+provision_virtual_esxi_vms:
+  - name: esxi-1
+  - name: esxi-2
+provision_virtual_esxi_networks: []
+provision_virtual_esxi_disks:
+  - size_gb: 100
+    type: thin
+    datastore: LocalDS_0


### PR DESCRIPTION
Split this from my old PR because it got too large.

-----

This change includes a new role to deploy ESXi hosts as virtual machines on an existing VCenter or physical ESXi host. 

The role takes a reduced set of hardware parameters and X number of VM names from the user. It checks for these X number of ESXi VMs and uses the hardware specification to create any that are missing. Some hardware settings are not parameterized and are based on VMWare recommendations or requirements.

Newly created VMs expect a mounted ESXi ISO file. The ISO used for the install should be configured for unattended install, but the user can manually complete the install if desired and the playbook will just wait for them to finish. ISO files are expected to be located on a datastore and that file path is passed in as a parameter.

This role could be used by people trying to test a new ESXi install or people setting up a nested virtualized VCenter deployment.
