### PR TITLE
make mac OS use correct binary to deploy vcenter

### DIFF
--- a/changelogs/fragments/38__mm-bugfix__provision-vcenter-use-mac-bin-to-deploy.yml
+++ b/changelogs/fragments/38__mm-bugfix__provision-vcenter-use-mac-bin-to-deploy.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - provision_vcenter - Use OS specific binary when deploying the VCSA appliance (mac vs generic linux) instead of always using linux
+  - >-
+    provision_vcenter - Only use hdiutil to mount ISO on mac instead of hdiutil + mount. The new approach provides more consistent results
+    when reading the ISO content as a file system

--- a/roles/provision_vcenter/tasks/deploy_from_iso.yml
+++ b/roles/provision_vcenter/tasks/deploy_from_iso.yml
@@ -1,9 +1,12 @@
 ---
-- name: Gather Required OS Facts
-  ansible.builtin.setup:
-    gather_subset:
-      - system
-  when: ansible_os_family is not defined
+- name: Mount vCSA ISO as Read-Only
+  ansible.builtin.include_tasks: "{{ item }}"
+  with_first_found:
+    - files:
+        - mount_{{ ansible_os_family | lower }}.yml
+        - mount_default.yml
+      paths:
+        - os_specific_iso_actions
 
 - name: Template Installer Config JSON
   ansible.builtin.template:
@@ -11,32 +14,11 @@
     dest: /tmp/vcsa_deployment_config.json
     mode: "0600"
 
-- name: Install from ISO
-  block:
-    - name: Mount vCSA ISO as Read-Only
-      ansible.builtin.include_tasks: "{{ item }}"
-      with_first_found:
-        - files:
-            - mount_{{ ansible_os_family | lower }}.yml
-            - mount_default.yml
-          paths:
-            - os_specific_iso_actions
-    - name: Deploy vCSA With Local Log Written To /tmp/vcsa.log
-      ansible.builtin.shell: >-
-        ./vcsa-deploy install -v --accept-eula --no-ssl-certificate-verification
-        --acknowledge-ceip /tmp/vcsa_deployment_config.json > /tmp/vcsa.log 2>&1
-      args:
-        chdir: "{{ provision_vcenter_iso_mount_point }}/vcsa-cli-installer/lin64"
-  always:
-    - name: Remove The Installer Config JSON
-      ansible.builtin.file:
-        path: /tmp/vcsa_deployment_config.json
-        state: absent
-    - name: Unmount vCSA ISO
-      ansible.builtin.include_tasks: "{{ item }}"
-      with_first_found:
-        - files:
-            - unmount_{{ ansible_os_family | lower }}.yml
-            - unmount_default.yml
-          paths:
-            - os_specific_iso_actions
+- name: Deploy vCSA With Local Log Written To /tmp/vcsa.log
+  ansible.builtin.shell: >-
+    ./vcsa-deploy install -v --accept-eula --no-ssl-certificate-verification
+    --acknowledge-ceip /tmp/vcsa_deployment_config.json > /tmp/vcsa.log 2>&1
+  args:
+    chdir: >-
+      {{ provision_vcenter_vcsa_iso_bin_dir[(ansible_os_family | lower)] |
+      default(provision_vcenter_vcsa_iso_bin_dir['default']) }}

--- a/roles/provision_vcenter/tasks/main.yml
+++ b/roles/provision_vcenter/tasks/main.yml
@@ -22,8 +22,28 @@
     _vcenter_lookup.msg is not match("Unable to gather information for non-existing VM .*")
 
 - name: Create Instance From ISO
-  ansible.builtin.include_tasks: deploy_from_iso.yml
   when: _vcenter_lookup.instance is not defined or not _vcenter_lookup.instance
+  block:
+    - name: Gather Required OS Facts
+      ansible.builtin.setup:
+        gather_subset:
+          - system
+      when: ansible_os_family is not defined
+    - name: Create Instance From ISO
+      ansible.builtin.include_tasks: deploy_from_iso.yml
+  always:
+    - name: Remove The Installer Config JSON
+      ansible.builtin.file:
+        path: /tmp/vcsa_deployment_config.json
+        state: absent
+    - name: Unmount vCSA ISO
+      ansible.builtin.include_tasks: "{{ item }}"
+      with_first_found:
+        - files:
+            - unmount_{{ ansible_os_family | lower }}.yml
+            - unmount_default.yml
+          paths:
+            - os_specific_iso_actions
 
 - name: Make Sure VCenter Appliance Is Powered On
   community.vmware.vmware_guest_powerstate:

--- a/roles/provision_vcenter/tasks/os_specific_iso_actions/mount_darwin.yml
+++ b/roles/provision_vcenter/tasks/os_specific_iso_actions/mount_darwin.yml
@@ -1,14 +1,7 @@
 ---
-- name: Attach vCSA ISO As Block Device
-  ansible.builtin.command:
-    cmd: "hdiutil attach -nomount {{ provision_vcenter_iso_path }}"
+- name: Mount vCSA ISO
+  ansible.builtin.command: >-
+    hdiutil attach -readonly -mountroot "{{ provision_vcenter_iso_mount_point }}"
+    "{{ provision_vcenter_iso_path }}"
   register: _attach_iso
-
-- name: Mount vCSA ISO Block Device
-  ansible.posix.mount:
-    src: "{{ _attach_iso.stdout_lines[0] | split(' ') | first }}"
-    path: "{{ provision_vcenter_iso_mount_point }}"
-    fstype: cd9660
-    opts: ro,noauto
-    state: ephemeral
   become: true

--- a/roles/provision_vcenter/tasks/os_specific_iso_actions/unmount_darwin.yml
+++ b/roles/provision_vcenter/tasks/os_specific_iso_actions/unmount_darwin.yml
@@ -1,13 +1,4 @@
 ---
-# We ignore unmount errors so the detach command is run no matter what. This prevents
-# the device from being left attached if the mount command was the one that failed.
-- name: Cleanup vCSA ISO Mount
-  block:
-    - name: Unmount vCSA Block Device
-      ansible.posix.mount:
-        path: "{{ provision_vcenter_iso_mount_point }}"
-        state: unmounted
-      become: true
-  always:
-    - name: Detach vCSA ISO Block Device
-      ansible.builtin.command: "hdiutil detach {{ _attach_iso.stdout_lines[0] | split(' ') | first }}"
+- name: Detach vCSA ISO
+  ansible.builtin.command: "hdiutil detach {{ _attach_iso.stdout_lines[0] | split(' ') | first }}"
+  become: true

--- a/roles/provision_vcenter/vars/main.yml
+++ b/roles/provision_vcenter/vars/main.yml
@@ -1,0 +1,3 @@
+provision_vcenter_vcsa_iso_bin_dir:
+  darwin: "{{ provision_vcenter_iso_mount_point }}/VMware VCSA/vcsa-cli-installer/mac"
+  default: "{{ provision_vcenter_iso_mount_point }}/vcsa-cli-installer/lin64"


### PR DESCRIPTION
This PR changes the VCSA binary used to deploy vcenter when on mac vs linux operating systems. It also simplifies the mounting mechanism for macs since the previous method caused occasional file system read issues