### PR TITLE
Mm feature/cluster settings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 ---
 name: Ansible Integration Test
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   pull_request:
   merge_group:
     branches:
@@ -27,5 +27,9 @@ jobs:
 
       - name: Run
         run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
           make integration
         working-directory: ansible_collections/cloud/vmware_ops
+        env:
+          ANSIBLE_COLLECTIONS_PATH: "${{ github.workspace }}"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install-python-packages:
 
 .PHONY: install-ansible-collections
 install-ansible-collections:
-	ansible-galaxy collection install -r tests/integration/requirements.yml
+	ansible-galaxy collection install --upgrade -r tests/integration/requirements.yml
 
 .PHONY: integration
 integration: install-python-packages install-ansible-collections

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Name | Description
 
 ### Requirements
 
-The [community.vmware](https://github.com/ansible-collections/community.vmware) (>4.3.0), [vmware.vmware_rest](https://github.com/ansible-collections/vmware.vmware_rest), [vmware.vmware](https://github.com/ansible-collections/vmware.vmware) and [community.general](https://github.com/ansible-collections/community.general) collections MUST be installed in order for this collection to work.
+The [community.vmware](https://github.com/ansible-collections/community.vmware) (>=4.4.0), [vmware.vmware_rest](https://github.com/ansible-collections/vmware.vmware_rest), [vmware.vmware](https://github.com/ansible-collections/vmware.vmware) and [community.general](https://github.com/ansible-collections/community.general) collections MUST be installed in order for this collection to work.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Name | Description
 
 ### Requirements
 
-The [community.vmware](https://github.com/ansible-collections/community.vmware), [vmware.vmware_rest](https://github.com/ansible-collections/vmware.vmware_rest), [vmware.vmware](https://github.com/ansible-collections/vmware.vmware) and [community.general](https://github.com/ansible-collections/community.general) collections MUST be installed in order for this collection to work.
+The [community.vmware](https://github.com/ansible-collections/community.vmware) (>4.3.0), [vmware.vmware_rest](https://github.com/ansible-collections/vmware.vmware_rest), [vmware.vmware](https://github.com/ansible-collections/vmware.vmware) and [community.general](https://github.com/ansible-collections/community.general) collections MUST be installed in order for this collection to work.
 
 ### Installation
 

--- a/changelogs/fragments/39__mm-feature__cluster-settings.yml
+++ b/changelogs/fragments/39__mm-feature__cluster-settings.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - cluster_settings - Added new role for managing different cluster settings including DRM, DRS, vCLS, HA, and vSAN. Added integration tests for role
+  - cluster_settings - Added new playbook to modify cluster settings

--- a/execution-environment/execution-environment.yml
+++ b/execution-environment/execution-environment.yml
@@ -8,6 +8,6 @@ dependencies:
   system:
     - python3-aiohttp [platform:rpm]
   python:
-    - pyvmomi
+    - pyvmomi<7.0.3
   ansible_core:
     package_pip: ansible-core==2.13.13

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -21,6 +21,6 @@ build_ignore:
   - .idea
 dependencies: {
   "vmware.vmware_rest": ">=2.3.1",
-  "community.vmware": ">=4.2.0",
+  "community.vmware": ">=4.4.0",
   "vmware.vmware": ">=1.0.0",
 }

--- a/playbooks/cluster_settings.yml
+++ b/playbooks/cluster_settings.yml
@@ -1,0 +1,7 @@
+---
+- name: Manage VMware Cluster Settings
+  hosts: localhost
+  gather_facts: false
+
+  roles:
+    - role: cloud.vmware_ops.cluster_settings

--- a/roles/cluster_settings/README.md
+++ b/roles/cluster_settings/README.md
@@ -1,0 +1,197 @@
+# Cluster settings role
+
+A role to define cluster settings in vCenter.
+
+## Requirements
+
+pyvmomi < 7.0.3
+
+In some cases, the vCLS cluster settings will fail to apply when using pyvmomi version 7.0.3 or greater. If this feature is required, using an earlier version will work.
+Support for version 7.0.3 and higher is planned for the next release of community.vmware (>4.4.0), at which point this restriction will be removed.
+
+## Role Variables
+### Auth
+- **cluster_settings_username**:
+  - The vSphere vCenter username.
+
+- **cluster_settings_password**:
+  - The vSphere vCenter password.
+
+- **cluster_settings_hostname**:
+  - The hostname or IP address of the vSphere vCenter.
+
+- **cluster_settings_validate_certs**
+  - Allows connection when SSL certificates are not valid. Set to false when certificates are not trusted.
+
+- **cluster_settings_cluster_name**:
+  - The name of the cluster in vSphere vCenter to configure.
+
+- **cluster_settings_datacenter_name**:
+  - The name of the datacenter in vSphere vCenter which contains the cluster to configure.
+
+- **cluster_settings_port**:
+  - str or int, The port to use to authenticate to the vSphere vCenter which contains the cluster to configure.
+
+### Cluster settings
+
+#### Distributed Power Management (DPM)
+
+- **cluster_settings_dpm_enable**:
+  - bool, If true, DPM will be enabled and configured using the settings below. If false, DPM will be disabled. If undefined, no action will be taken
+
+- **cluster_settings_dpm_default_behavior**:
+  - str, Set the DPM behavior. Value should be 'automated' or 'manual'
+
+- **cluster_settings_dpm_host_power_action_rate**:
+  - int, Specify host power action rate as a number 1-5. 1 is the most conservative and 5 the most aggressive
+
+
+#### DRS
+
+- **cluster_settings_drs_enable**:
+  - bool, If true, DRS will be enabled and configured using the settings below. If false, DRS will be disabled. If undefined, no action will be taken
+
+- **cluster_settings_drs_enable_vm_behavior_overrides**:
+  - bool, If true, DRS Behavior overrides for individual virtual machines are enabled.
+
+- **cluster_settings_drs_enable_vm_behavior**
+  - str, Specifies the cluster-wide default DRS behavior for virtual machines.
+  - If set to `partiallyAutomated`, vCenter generates recommendations for virtual machine migration and for the placement with a host, then automatically implements placement recommendations at power on.
+  - If set to `manual`, then vCenter generates recommendations for virtual machine migration and for the placement with a host, but does not implement the recommendations automatically.
+  - If set to `fullyAutomated`, then vCenter automates both the migration of virtual machines and their placement with a host at power on.
+
+- **cluster_settings_drs_vmotion_rate**:
+  - int, Threshold for generated ClusterRecommendations ranging from 1 (lowest) to 5 (highest).
+
+- **cluster_settings_drs_advanced_settings**
+  - dict, A dictionary of advanced DRS settings.
+
+- **cluster_settings_drs_predictive**:
+  - bool, If true, DRS will respond to forecasted metrics provided by vRealize Operations Manager in addition to real-time metrics.
+  - You must have already configured Predictive DRS in a version of vRealize Operations that supports this feature.
+
+- **cluster_settings_drs_apply_recommendations**:
+  - bool, If true, apply available DRS recommendations after DRS settings above are configured. Default is False
+
+
+#### Cluster HA
+
+- **cluster_settings_ha_enable**:
+  - bool, If true, HA will be enabled and configured using the settings below. If false, HA will be disabled. If undefined, no action will be taken
+
+- **cluster_settings_ha_host_monitoring**:
+  - str, Whether HA restarts virtual machines after a host fails. Either `enabled` or `disabled`
+
+- **cluster_settings_ha_vm_monitoring**:
+  - str, State of virtual machine health monitoring service. One of `vmAndAppMonitoring`, `vmMonitoringDisabled`, `vmMonitoringOnly`
+
+- **cluster_settings_ha_host_isolation_response**:
+  - str, Indicates whether or VMs should be powered off if a host determines that it is isolated from the rest of the compute resource. One of `none`, `powerOff`, `powerOn`
+
+- **cluster_settings_ha_slot_based_admission_control**:
+  - dict, Configure slot based admission control policy.
+  - `cluster_settings_ha_slot_based_admission_control`, `cluster_settings_ha_reservation_based_admission_control` and `cluster_settings_ha_failover_host_admission_control` are mutually exclusive.
+  - Refer to this documentation for child attributes https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_cluster_ha_module.html#parameter-slot_based_admission_control
+
+- **cluster_settings_ha_reservation_based_admission_control**:
+  - dict, Configure reservation based admission control policy.
+  - `cluster_settings_ha_slot_based_admission_control`, `cluster_settings_ha_reservation_based_admission_control` and `cluster_settings_ha_failover_host_admission_control` are mutually exclusive.
+  - Refer to this documentation for child attributes https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_cluster_ha_module.html#parameter-reservation_based_admission_control
+
+- **cluster_settings_ha_failover_host_admission_control**:
+  - dict, Configure dedicated failover hosts.
+  - `cluster_settings_ha_slot_based_admission_control`, `cluster_settings_ha_reservation_based_admission_control` and `cluster_settings_ha_failover_host_admission_control` are mutually exclusive.
+  - Refer to this documentation for child attributes https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_cluster_ha_module.html#parameter-failover_host_admission_control
+
+- **cluster_settings_ha_vm_failure_interval**:
+  - int, The number of seconds after which virtual machine is declared as failed if no heartbeat has been received.
+  - Used only when `cluster_settings_ha_vm_monitoring` is `vmAndAppMonitoring` or `vmMonitoringOnly`
+
+- **cluster_settings_ha_vm_min_up_time**:
+  - int, The number of seconds for the virtual machine's heartbeats to stabilize after the virtual machine has been powered on.
+  - Used only when `cluster_settings_ha_vm_monitoring` is `vmAndAppMonitoring` or `vmMonitoringOnly`
+
+- **cluster_settings_ha_vm_max_failures**:
+  - int, Maximum number of failures and automated resets allowed during the time that ha_vm_max_failure_window specifies.
+  - Used only when `cluster_settings_ha_vm_monitoring` is `vmAndAppMonitoring` or `vmMonitoringOnly`
+
+- **cluster_settings_ha_vm_max_failure_window**:
+  - int, The number of seconds for the window during which up to `cluster_settings_ha_vm_max_failures` resets can occur before automated responses stop. Default specifies no failure window.
+  - Used only when `cluster_settings_ha_vm_monitoring` is `vmAndAppMonitoring` or `vmMonitoringOnly`
+
+- **cluster_settings_ha_restart_priority**:
+  - str, The priority HA gives to a virtual machine if sufficient capacity is not available to power on all failed virtual machines. Options are `disabled`, `low`, `medium`, or `high`
+  - Used only when `cluster_settings_ha_vm_monitoring` is `vmAndAppMonitoring` or `vmMonitoringOnly`
+
+- **cluster_settings_ha_advanced_settings**:
+  - dict, A dictionary of advanced HA settings.
+
+- **cluster_settings_ha_apd_response**:
+  - str, VM storage protection setting for storage failures categorized as All Paths Down (APD).
+  - Options are `disabled`, `warning`, `restartConservative`, `restartAggressive`
+
+- **cluster_settings_ha_apd_delay**:
+  - int, The response recovery delay time in sec for storage failures categorized as All Paths Down (APD).
+  - Used only when `cluster_settings_ha_apd_response` is `restartConservative` or `restartAggressive`.
+
+- **cluster_settings_ha_apd_reaction**:
+  - str, VM response recovery reaction for storage failures categorized as All Paths Down (APD). Either `reset` or `none`
+  - Used only when `cluster_settings_ha_apd_response` is `restartConservative` or `restartAggressive`.
+
+- **cluster_settings_ha_pdl_response**:
+  - str, VM storage protection setting for storage failures categorized as Permenant Device Loss (PDL).
+  - Options are `disabled`, `warning`, `restartAggressive`
+
+
+#### vCLS Datastore
+
+- **cluster_settings_vcls_allowed_datastores**:
+  - list, List of the allowed Datastores. Any currently allowed datastores not in the list will be removed.
+  - If this is undefined, no action is taken.
+
+#### vSAN
+- **cluster_settings_vsan_enable**:
+  - bool, If true, vSAN will be enabled and configured using the parameters below. If false, vSAN will be disabled. If undefined, no action will be taken
+
+- **cluster_settings_vsan_auto_claim_storage**:
+  - bool, If true, the VSAN service is configured to automatically claim local storage on VSAN-enabled hosts in the cluster.
+
+- **cluster_settings_vsan_advanced_options**:
+  - A dictionary of advanced vSAN options. Suboptions include:
+  - `automatic_rebalance`: bool, If true, vSAN automatically rebalances (moves the data among disks) when a capacity disk fullness hits proactive rebalance threshold.
+  - `disable_site_read_locality`: bool, For vSAN stretched clusters, reads to vSAN objects occur on the site the VM resides on. Setting to true will force reads across all mirrors.
+  - `large_cluster_support`: bool, If true, allow > 32 VSAN hosts per cluster. If this is changed on an existing vSAN cluster, all hosts are required to reboot to apply this change.
+  - `object_repair_timer`: int, Delay time in minutes for VSAN to wait for the absent component to come back before starting to repair it.
+  - `thin_swap`: bool, If true, swap objects would not reserve 100% space of their size on vSAN datastore.
+
+### Other
+- **cluster_settings_proxy_host**:
+  - str, The hostname of a proxy host that should be used for all HTTPs communication by the role. Optional
+
+- **cluster_settings_proxy_port**:
+  - str, The port of a proxy host that should be used for all HTTPs communication by the role. Optional
+
+
+## Dependencies
+
+- vmware.vmware_rest
+
+## Example Playbook
+```yaml
+---
+- name: Manage vmware cluster settings
+  hosts: all
+  gather_facts: false
+
+  roles:
+    - role: cloud.vmware_ops.cluster_settings
+```
+## License
+
+GNU General Public License v3.0 or later
+
+See [LICENCE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
+
+## Author Information
+
+- Ansible Cloud Content Team

--- a/roles/cluster_settings/defaults/main.yml
+++ b/roles/cluster_settings/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+cluster_settings_drs_apply_recommendations: false

--- a/roles/cluster_settings/tasks/main.yml
+++ b/roles/cluster_settings/tasks/main.yml
@@ -88,15 +88,6 @@
     pdl_response: "{{ cluster_settings_ha_pdl_response | default(omit) }}"
   when: cluster_settings_ha_enable is defined
 
-- name: Command
-  ansible.builtin.shell: pip freeze
-  register: _o
-  changed_when: False
-
-- name: Debug
-  debug:
-    var: _o.stdout
-
 - name: Configure vCLS Datastore Settings
   community.vmware.vmware_cluster_vcls:
     hostname: "{{ cluster_settings_hostname }}"

--- a/roles/cluster_settings/tasks/main.yml
+++ b/roles/cluster_settings/tasks/main.yml
@@ -1,0 +1,128 @@
+---
+- name: Check Mandatory Variables Are Defined
+  ansible.builtin.assert:
+    that:
+      - cluster_settings_datacenter_name is defined
+      - cluster_settings_cluster_name is defined
+      - cluster_settings_hostname is defined
+      - cluster_settings_username is defined
+      - cluster_settings_password is defined
+    quiet: true
+    fail_msg: Variable must be set when using this role.
+
+- name: Configure DPM Settings
+  community.vmware.vmware_cluster_dpm:
+    hostname: "{{ cluster_settings_hostname }}"
+    username: "{{ cluster_settings_username }}"
+    password: "{{ cluster_settings_password }}"
+    validate_certs: "{{ cluster_settings_validate_certs | default(omit) }}"
+    port: "{{ cluster_settings_port | default(omit) }}"
+    proxy_host: "{{ cluster_settings_proxy_host | default(omit) }}"
+    proxy_port: "{{ cluster_settings_proxy_port | default(omit) }}"
+    datacenter_name: "{{ cluster_settings_datacenter_name }}"
+    cluster_name: "{{ cluster_settings_cluster_name }}"
+    enable_dpm: "{{ cluster_settings_dpm_enable | bool }}"
+    default_dpm_behaviour: "{{ cluster_settings_dpm_default_behavior | default(omit) }}"
+    host_power_action_rate: "{{ cluster_settings_dpm_host_power_action_rate | default(omit) }}"
+  when: cluster_settings_dpm_enable is defined
+
+- name: Configure DRS Settings
+  community.vmware.vmware_cluster_drs:
+    hostname: "{{ cluster_settings_hostname }}"
+    username: "{{ cluster_settings_username }}"
+    password: "{{ cluster_settings_password }}"
+    validate_certs: "{{ cluster_settings_validate_certs | default(omit) }}"
+    port: "{{ cluster_settings_port | default(omit) }}"
+    proxy_host: "{{ cluster_settings_proxy_host | default(omit) }}"
+    proxy_port: "{{ cluster_settings_proxy_port | default(omit) }}"
+    datacenter_name: "{{ cluster_settings_datacenter_name }}"
+    cluster_name: "{{ cluster_settings_cluster_name }}"
+    enable: "{{ cluster_settings_drs_enable | bool }}"
+    drs_enable_vm_behavior_overrides: "{{ cluster_settings_drs_enable_vm_behavior_overrides | default(omit) }}"
+    drs_default_vm_behavior: "{{ cluster_settings_drs_enable_vm_behavior | default(omit) }}"
+    drs_vmotion_rate: "{{ cluster_settings_drs_vmotion_rate | default(omit) }}"
+    advanced_settings: "{{ cluster_settings_drs_advanced_settings | default(omit) }}"
+    predictive_drs: "{{ cluster_settings_drs_predictive | default(omit) }}"
+  when: cluster_settings_drs_enable is defined
+
+- name: Apply DRS Recommendations for Cluster
+  community.vmware.vmware_cluster:
+    hostname: "{{ cluster_settings_hostname }}"
+    username: "{{ cluster_settings_username }}"
+    password: "{{ cluster_settings_password }}"
+    validate_certs: "{{ cluster_settings_validate_certs | default(omit) }}"
+    port: "{{ cluster_settings_port | default(omit) }}"
+    proxy_host: "{{ cluster_settings_proxy_host | default(omit) }}"
+    proxy_port: "{{ cluster_settings_proxy_port | default(omit) }}"
+    datacenter_name: "{{ cluster_settings_datacenter_name }}"
+    cluster_name: "{{ cluster_settings_cluster_name }}"
+  when: cluster_settings_drs_apply_recommendations
+
+- name: Configure Cluster HA Settings
+  community.vmware.vmware_cluster_ha:
+    hostname: "{{ cluster_settings_hostname }}"
+    username: "{{ cluster_settings_username }}"
+    password: "{{ cluster_settings_password }}"
+    validate_certs: "{{ cluster_settings_validate_certs | default(omit) }}"
+    port: "{{ cluster_settings_port | default(omit) }}"
+    proxy_host: "{{ cluster_settings_proxy_host | default(omit) }}"
+    proxy_port: "{{ cluster_settings_proxy_port | default(omit) }}"
+    datacenter_name: "{{ cluster_settings_datacenter_name }}"
+    cluster_name: "{{ cluster_settings_cluster_name }}"
+    enable: "{{ cluster_settings_ha_enable }}"
+    ha_host_monitoring: "{{ cluster_settings_ha_host_monitoring | default(omit) }}"
+    ha_vm_monitoring: "{{ cluster_settings_ha_vm_monitoring | default(omit) }}"
+    host_isolation_response: "{{ cluster_settings_ha_host_isolation_response | default(omit) }}"
+    slot_based_admission_control: "{{ cluster_settings_ha_slot_based_admission_control | default(omit) }}"
+    reservation_based_admission_control: "{{ cluster_settings_ha_reservation_based_admission_control | default(omit) }}"
+    failover_host_admission_control: "{{ cluster_settings_ha_failover_host_admission_control | default(omit) }}"
+    ha_vm_failure_interval: "{{ cluster_settings_ha_vm_failure_interval | default(omit) }}"
+    ha_vm_min_up_time: "{{ cluster_settings_ha_vm_min_up_time | default(omit) }}"
+    ha_vm_max_failures: "{{ cluster_settings_ha_vm_max_failures | default(omit) }}"
+    ha_vm_max_failure_window: "{{ cluster_settings_ha_vm_max_failure_window | default(omit) }}"
+    ha_restart_priority: "{{ cluster_settings_ha_restart_priority | default(omit) }}"
+    advanced_settings: "{{ cluster_settings_ha_advanced_settings | default(omit) }}"
+    apd_response: "{{ cluster_settings_ha_apd_response | default(omit) }}"
+    apd_delay: "{{ cluster_settings_ha_apd_delay | default(omit) }}"
+    apd_reaction: "{{ cluster_settings_ha_apd_reaction | default(omit) }}"
+    pdl_response: "{{ cluster_settings_ha_pdl_response | default(omit) }}"
+  when: cluster_settings_ha_enable is defined
+
+- name: Command
+  ansible.builtin.shell: pip freeze
+  register: _o
+  changed_when: False
+
+- name: Debug
+  debug:
+    var: _o.stdout
+
+- name: Configure vCLS Datastore Settings
+  community.vmware.vmware_cluster_vcls:
+    hostname: "{{ cluster_settings_hostname }}"
+    username: "{{ cluster_settings_username }}"
+    password: "{{ cluster_settings_password }}"
+    validate_certs: "{{ cluster_settings_validate_certs | default(omit) }}"
+    port: "{{ cluster_settings_port | default(omit) }}"
+    proxy_host: "{{ cluster_settings_proxy_host | default(omit) }}"
+    proxy_port: "{{ cluster_settings_proxy_port | default(omit) }}"
+    datacenter_name: "{{ cluster_settings_datacenter_name }}"
+    cluster_name: "{{ cluster_settings_cluster_name }}"
+    allowed_datastores: "{{ cluster_settings_vcls_allowed_datastores }}"
+  when: cluster_settings_vcls_allowed_datastores is defined
+
+- name: Configure vSAN Settings
+  community.vmware.vmware_cluster_vsan:
+    hostname: "{{ cluster_settings_hostname }}"
+    username: "{{ cluster_settings_username }}"
+    password: "{{ cluster_settings_password }}"
+    validate_certs: "{{ cluster_settings_validate_certs | default(omit) }}"
+    port: "{{ cluster_settings_port | default(omit) }}"
+    proxy_host: "{{ cluster_settings_proxy_host | default(omit) }}"
+    proxy_port: "{{ cluster_settings_proxy_port | default(omit) }}"
+    datacenter_name: "{{ cluster_settings_datacenter_name }}"
+    cluster_name: "{{ cluster_settings_cluster_name }}"
+    enable: "{{ cluster_settings_vsan_enable }}"
+    vsan_auto_claim_storage: "{{ cluster_settings_vsan_auto_claim_storage | default(omit) }}"
+    advanced_options: "{{ cluster_settings_vsan_advanced_options | default(omit) }}"
+  when: cluster_settings_vsan_enable is defined

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,5 +1,9 @@
 pyVim
-pyVmomi>=6.7
 podman
 requests
 pycdlib
+ansible-core
+
+# see the cluster_settings role README.md for an explanation on the <7.0.3 restriction
+pyVmomi>=6.7,<7.0.3
+

--- a/tests/integration/requirements.yml
+++ b/tests/integration/requirements.yml
@@ -1,5 +1,8 @@
 collections:
+  - name: community.general
+  - name: ansible.posix
   - name: community.vmware
+    version: ">=4.4.0"
   - name: vmware.vmware_rest
   - name: vmware.vmware
   - name: containers.podman

--- a/tests/integration/targets/cluster_settings_test/run.yml
+++ b/tests/integration/targets/cluster_settings_test/run.yml
@@ -1,0 +1,13 @@
+- hosts: localhost
+  gather_facts: no
+  collections:
+    - community.general
+
+  tasks:
+    - name: Vcsim
+      ansible.builtin.import_role:
+        name: prepare_soap
+
+    - name: Import provision VM role
+      ansible.builtin.import_role:
+        name: cluster_settings_test

--- a/tests/integration/targets/cluster_settings_test/runme.sh
+++ b/tests/integration/targets/cluster_settings_test/runme.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+source ../init.sh
+exec ansible-playbook run.yml

--- a/tests/integration/targets/cluster_settings_test/tasks/main.yml
+++ b/tests/integration/targets/cluster_settings_test/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Test Cluster DPM Settings
+  ansible.builtin.import_role:
+    name: cloud.vmware_ops.cluster_settings

--- a/tests/integration/targets/cluster_settings_test/vars/main.yml
+++ b/tests/integration/targets/cluster_settings_test/vars/main.yml
@@ -1,0 +1,27 @@
+---
+cluster_settings_hostname: "127.0.0.1"
+cluster_settings_username: "test"
+cluster_settings_password: "test"
+cluster_settings_validate_certs: false
+cluster_settings_port: "8989"
+cluster_settings_cluster_name: "DC0_C0"
+cluster_settings_datacenter_name: "DC0"
+
+# DPM
+cluster_settings_dpm_enable: True
+
+# DRS
+cluster_settings_drs_enable: True
+cluster_settings_drs_apply_recommendations: True
+
+# HA
+cluster_settings_ha_enable: True
+
+# vCLS
+cluster_settings_vcls_allowed_datastores:
+  - LocalDS_0
+#
+# Disabled vSAN tests because they require an SDK
+# from VMWare that is not publically accessible
+# vSAN
+# cluster_settings_vsan_enable: False


### PR DESCRIPTION
Adding playbook and role to manage cluster settings for a vCenter cluster.

The user can optionally modify DRS, DRM, vCLS, HA, and vSAN settings on their cluster. Each group of settings can be configured, enabled/disabled, or omitted independently.

I added a playbook for general settings. I will add another playbook specifically for modifying HA status under another ticket.

I was not able to add integration tests for the vSAN settings due to a required SDK that can only be downloaded from VMWare with a customer login. Im making followup tickets to research ways around that
