### PR TITLE
add first integration CI test to run on eco vcenter

### DIFF
--- a/.github/workflows/eco-vcenter-ci.yaml
+++ b/.github/workflows/eco-vcenter-ci.yaml
@@ -1,0 +1,46 @@
+---
+name: Ansible Eco vCenter Integration Test
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+      - 'release-\d.\d'
+permissions:
+  contents: read
+jobs:
+  ansible_integration_test:
+    runs-on: ["self-hosted", linux, X64]
+    steps:
+      - name: Update pip, git
+        if: runner.os == 'Linux' && startsWith(runner.name, 'ubuntu')
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install podman
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: ansible_collections/cloud/vmware_ops
+
+      - name: Generate integration config
+        working-directory: ansible_collections/cloud/vmware_ops/tests/integration
+        run: |
+          chmod +x generate_integration_config.sh
+          ./generate_integration_config.sh
+        env:
+          VCENTER_HOSTNAME: ${{ secrets.VCENTER_HOSTNAME }}
+          VCENTER_USERNAME: ${{ secrets.VCENTER_USERNAME }}
+          VCENTER_PASSWORD: ${{ secrets.VCENTER_PASSWORD }}
+
+      - name: Run integration tests
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          make eco-vcenter-ci
+        working-directory: ansible_collections/cloud/vmware_ops
+        env:
+          ANSIBLE_COLLECTIONS_PATH: "${{ github.workspace }}"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,11 @@
-*       @bardielle
-*       @machacekondra
-*       @mikemorency
+# Default code owners for all files and directories
+*       @bardielle @machacekondra @mikemorency
+
+# Integration tests permissions
+/tests/integration/ @shellymiron @elsapassaro
+
+# Specific workflow file permissions
+.github/workflows/eco-vcenter-ci.yaml @shellymiron @elsapassaro
+
+# Scripts directory permissions
+/scripts/ @shellymiron @elsapassaro

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,19 @@ install-python-packages:
 install-ansible-collections:
 	ansible-galaxy collection install --upgrade -r tests/integration/requirements.yml
 
+# workaround pyvmomy issue till latest version
+# is available to use in requirements.txt
+.PHONY: install-pyvmomy-latest
+install-pyvmomy-latest:
+	pip3 install pyVmomi --force
+
 .PHONY: integration
 integration: install-python-packages install-ansible-collections
 	ansible-test integration --no-temp-workdir
+
+.PHONY: eco-vcenter-ci
+eco-vcenter-ci: install-python-packages install-ansible-collections install-pyvmomy-latest
+	ansible-test integration --no-temp-workdir info_test
 
 .PHONY: ee-clean
 ee-clean:

--- a/changelogs/fragments/42__eco-vcenter-ci-integration.yml
+++ b/changelogs/fragments/42__eco-vcenter-ci-integration.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - info_test - adding a CI for validated content repo to run on a real vcenter env,
+    and include this test within the pr

--- a/tests/integration/generate_integration_config.sh
+++ b/tests/integration/generate_integration_config.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2155,SC2086
+
+# Resolve the script's directory reliably
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+# Truncate the output file
+truncate -s 0 integration_config.yml
+
+# Read the template and substitute environment variables
+while read -r line; do
+    eval 'echo "'"$line"'"' >> integration_config.yml
+done < "integration_config.yml.tpl"

--- a/tests/integration/integration_config.yml.tpl
+++ b/tests/integration/integration_config.yml.tpl
@@ -1,0 +1,5 @@
+---
+vcenter_hostname: ${VCENTER_HOSTNAME}
+vcenter_username: ${VCENTER_USERNAME}
+vcenter_password: ${VCENTER_PASSWORD}
+ansible_tags: eco-vcenter-ci

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp
 pyVim
 podman
 requests
@@ -6,4 +7,4 @@ ansible-core
 
 # see the cluster_settings role README.md for an explanation on the <7.0.3 restriction
 pyVmomi>=6.7,<7.0.3
-
+git+https://github.com/vmware/vsphere-automation-sdk-python.git

--- a/tests/integration/targets/info_test/defaults/main.yml
+++ b/tests/integration/targets/info_test/defaults/main.yml
@@ -1,0 +1,13 @@
+info_hostname: "{{ vcenter_hostname }}"
+info_username: "{{ vcenter_username }}"
+info_password: "{{ vcenter_password }}"
+info_validate_certs: false
+info_appliance_file: "/tmp/info_appliance_file"
+info_license_file: "/tmp/info_license_file"
+info_storage_file: "/tmp/info_storage_file"
+info_guest_file: "/tmp/guest_info_file"
+info_license: true
+info_storage: true
+info_cluster: true
+info_guest: true
+info_appliance: true

--- a/tests/integration/targets/info_test/run.yml
+++ b/tests/integration/targets/info_test/run.yml
@@ -1,19 +1,34 @@
-- hosts: localhost
-  gather_facts: no
+- name: Run Info Test Tasks
+  hosts: localhost
+  gather_facts: false
   collections:
     - community.general
-  vars_files:
-    - vars.yml
 
   tasks:
-    - name: Vcsim
-      ansible.builtin.import_role:
-        name: prepare_soap
 
-    - name: Vcsim
+    - name: Import eco-vcenter credentials
+      ansible.builtin.include_vars:
+        file: ../../integration_config.yml
+      tags: eco-vcenter-ci
+
+    - name: Import simulator vars
+      ansible.builtin.include_vars:
+        file: vars.yml
+      tags: integration-ci
+
+    - name: Prepare Rest
       ansible.builtin.import_role:
         name: prepare_rest
+      tags: integration-ci
+
+    - name: Prepare Soap (vcsim)
+      ansible.builtin.import_role:
+        name: prepare_soap
+      tags: integration-ci
 
     - name: Import info role
       ansible.builtin.import_role:
         name: info_test
+      tags:
+        - eco-vcenter-ci
+        - integration-ci

--- a/tests/integration/targets/info_test/runme.sh
+++ b/tests/integration/targets/info_test/runme.sh
@@ -1,3 +1,14 @@
 #!/usr/bin/env bash
 source ../init.sh
-exec ansible-playbook run.yml
+
+# Extract the ansible_tags from integration_config.yml
+ANSIBLE_TAGS=$(awk '/ansible_tags/ {print $2}' ../../integration_config.yml)
+
+# Check if the ANSIBLE_TAGS variable is set
+if [[ -n "$ANSIBLE_TAGS" ]]; then
+  echo "ANSIBLE_TAGS is set to: $ANSIBLE_TAGS"
+  exec ansible-playbook run.yml --tags "$ANSIBLE_TAGS"
+else
+  echo "ANSIBLE_TAGS is not set for Eco vCenter. Running on simulator."
+  exec ansible-playbook run.yml --tags integration-ci
+fi

--- a/tests/integration/targets/info_test/vars.yml
+++ b/tests/integration/targets/info_test/vars.yml
@@ -7,4 +7,11 @@ info_validate_certs: false
 
 mock_file: "info_test"
 
-info_cluster: true
+# workaround till simulator fixed in the next release-
+# check doc in cloud.vmware_ops/roles/cluster_settings
+# for pyvmomi current version limitation
+info_cluster: false
+info_license: true
+info_appliance: false
+info_guest: false
+info_storage: false

--- a/tests/integration/targets/init.sh
+++ b/tests/integration/targets/init.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2155,SC2086
 
-BASE_DIR=$(dirname "${BASH_SOURCE[0]}")
+# Export the collections path
+export ANSIBLE_COLLECTIONS_PATH="$ANSIBLE_COLLECTIONS_PATH/ansible_collections"
+
+echo "ANSIBLE_COLLECTIONS_PATH: $ANSIBLE_COLLECTIONS_PATH"
+BASE_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 export ANSIBLE_ROLES_PATH=${BASE_DIR}

--- a/tests/integration/targets/prepare_rest/tasks/main.yml
+++ b/tests/integration/targets/prepare_rest/tasks/main.yml
@@ -4,6 +4,8 @@
     name:
       - requests
       - aiohttp
+      - pyvmomi
+      - git+https://github.com/vmware/vsphere-automation-sdk-python.git@v7.0.3.2
 
 - name: Run rest
   containers.podman.podman_container:

--- a/tests/integration/targets/prepare_soap/tasks/main.yml
+++ b/tests/integration/targets/prepare_soap/tasks/main.yml
@@ -4,11 +4,11 @@
     name:
       - requests
       - pyVmomi
+      - git+https://github.com/vmware/vsphere-automation-sdk-python.git
 
 - name: Run soap vcSim
   containers.podman.podman_container:
     name: vmwaresoap
-
     image: docker.io/vmware/vcsim:latest
     state: started
     recreate: yes


### PR DESCRIPTION
This PR is the first step to establish a CI in upstream (similar CI will be opened for vmware.vmware repo), that runs the integration tests on the real vcenter environment we have behind redhat vpn.

**Few notes:**

- This PR includes the action itself, some enhancements and modifications to the current info test we have in the 
   integration folder. the intention is to do the same for the rest of the integration tests (existing and new ones) one by 
   one, so that they could run both on vcsim (or as rest calls) and on the real vcenter env.

- In order for the PR to work, and so does others, I'll need to request to add the following secrets github env to the current repo: VCENTER_HOSTNAME, VCENTER_PASSWORD, VCENTER_USERNAME. I'll need dev for that, so will ask one of you for a help with that @bardielle @mikemorency @machacekondra 

- The info test is skipped for current CI integration (vcsim) as I can tell from looking in other PRs jobs. in my PR it is not skipped, hence, it is failing and I'll need dev assistance to see why and how to fix that. other tests seems to work.

Please help to review and be as much critical as you can :D  
(note - the jobs will not run properly before we will do the adjustments as described above, you can take a look of how it supposed to be after the changes [here](https://github.com/shellymiron/cloud.vmware_ops/pull/17))

also, check the [epic here](https://issues.redhat.com/browse/ACA-1312) for better understand the effort for this CI.