### PR TITLE
Add verification step to content_library integration tests

### DIFF
--- a/tests/integration/targets/vmware_ops_content_library_test/tasks/get_content_library_info.yml
+++ b/tests/integration/targets/vmware_ops_content_library_test/tasks/get_content_library_info.yml
@@ -1,0 +1,18 @@
+---
+- name: Get list of content libraries IDs
+  community.vmware.vmware_content_library_info:
+    hostname: "{{ content_library_hostname }}"
+    username: "{{ content_library_username }}"
+    password: "{{ content_library_password }}"
+    validate_certs: "{{ content_library_validate_certs }}"
+  register: content_library_ids
+
+- name: Get content library info
+  community.vmware.vmware_content_library_info:
+    hostname: "{{ content_library_hostname }}"
+    username: "{{ content_library_username }}"
+    password: "{{ content_library_password }}"
+    validate_certs: "{{ content_library_validate_certs }}"
+    library_id: "{{ item }}"
+  loop: "{{ content_library_ids.content_libs }}"
+  register: content_library_details

--- a/tests/integration/targets/vmware_ops_content_library_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_content_library_test/tasks/main.yml
@@ -6,9 +6,34 @@
     - name: Create Content Library
       ansible.builtin.import_role:
         name: cloud.vmware_ops.content_library
+
+    - name: Get content libraries info
+      ansible.builtin.import_tasks: get_content_library_info.yml
+
+    - name: "Fail if content library {{ content_library_name }} does not exist"
+      ansible.builtin.fail:
+        msg: "Content library {{ content_library_name }} does not exist"
+      when: content_library_details.results | map(attribute='content_lib_details') | flatten | map(attribute='library_name') is not ansible.builtin.contains(content_library_name)
+
+    - name: Verify content library details
+      ansible.builtin.assert:
+        that:
+          - item.content_lib_details[0].library_description == content_library_description
+          - item.content_lib_details[0].library_type | lower == content_library_type
+      when: item.content_lib_details[0].library_name == content_library_name
+      loop: "{{ content_library_details.results }}"
+
   always:
     - name: Destroy Content Library
       ansible.builtin.import_role:
         name: cloud.vmware_ops.content_library
       vars:
         content_library_state: absent
+
+    - name: Get content libraries info
+      ansible.builtin.import_tasks: get_content_library_info.yml
+
+    - name: "Fail if content library {{ content_library_name }} still exists"
+      ansible.builtin.fail:
+        msg: "Content library {{ content_library_name }} still exists"
+      when: content_library_details.results | map(attribute='content_lib_details') | flatten | map(attribute='library_name') is ansible.builtin.contains(content_library_name)

--- a/tests/integration/targets/vmware_ops_content_library_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_content_library_test/vars/main.yml
@@ -8,3 +8,4 @@ content_library_datacenter_name: Eco-Datacenter
 content_library_datastore_name: "datastore3"
 content_library_type: local
 content_library_name: eco-vcenter-ci-vmware-content-library-test
+content_library_description: "Test content library"


### PR DESCRIPTION
Adding checks to assert that the content library has been created with the given parameters. 
Depends on [PR 51](https://github.com/redhat-cop/cloud.vmware_ops/pull/51)