### PR TITLE
Mm feature/aca 1592 create vm template

### DIFF
--- a/changelogs/fragments/62__mm-feature_provision_template.yml
+++ b/changelogs/fragments/62__mm-feature_provision_template.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - manage_template - add playbook to manage templates using provision_vm role

--- a/playbooks/provision_vm/manage_template.yml
+++ b/playbooks/provision_vm/manage_template.yml
@@ -1,0 +1,7 @@
+---
+- name: Playbook to provision a new Template on VMware
+  hosts: all
+  gather_facts: false
+  roles:
+    - role: cloud.vmware_ops.provision_vm
+      provison_vm_template: true

--- a/playbooks/provision_vm/manage_template.yml
+++ b/playbooks/provision_vm/manage_template.yml
@@ -1,7 +1,8 @@
 ---
-- name: Playbook to provision a new Template on VMware
+- name: Playbook to provision a Template on VMware
   hosts: all
   gather_facts: false
+
   roles:
     - role: cloud.vmware_ops.provision_vm
       provison_vm_template: true

--- a/playbooks/provision_vm/manage_template.yml
+++ b/playbooks/provision_vm/manage_template.yml
@@ -5,4 +5,4 @@
 
   roles:
     - role: cloud.vmware_ops.provision_vm
-      provison_vm_template: true
+      provision_vm_template: true


### PR DESCRIPTION
Adding playbook to create a template from a VM, or a completely new template.

I think leveraging the existing provision_vm role makes sense instead of creating a new role for this, but having a dedicated playbook may make it easier for a user to create a template if they are unfamiliar with content/just looking at the list of available playbooks in AAP.

There are some additional validation steps that could be added as a pre_tasks or in a standalone role, but they are situational I think. Like, if a user is converting an existing VM to a template they need to power it off first. We could check that as part of this playbook but not every user would need or maybe even want that.