### PR TITLE
add provision_vm_is_template option

### DIFF
--- a/changelogs/fragments/73__mm-feature_add_provision_vm_template_opt.yml
+++ b/changelogs/fragments/73__mm-feature_add_provision_vm_template_opt.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - provision_vm - Added parameter to set is_template and defaulted it to false to keep behavior consistent

--- a/playbooks/provision_vm/manage_template.yml
+++ b/playbooks/provision_vm/manage_template.yml
@@ -5,4 +5,4 @@
 
   roles:
     - role: cloud.vmware_ops.provision_vm
-      provision_vm_template: true
+      provision_vm_is_template: true

--- a/playbooks/provision_vm/manage_vm.yml
+++ b/playbooks/provision_vm/manage_vm.yml
@@ -4,3 +4,4 @@
   gather_facts: false
   roles:
     - role: cloud.vmware_ops.provision_vm
+      provision_vm_is_template: false

--- a/roles/provision_vm/README.md
+++ b/roles/provision_vm/README.md
@@ -3,7 +3,7 @@ A role to provision a virtual machine, create associated resources if they don't
 This includes cloning and building from VM templates.
 
 
-## Requirements 
+## Requirements
 N/A
 
 
@@ -57,7 +57,7 @@ N/A
 - **provision_vm_esxi_hostname** (string):
     The ESXi hostname where the virtual machine will run.
     This is a required parameter, if cluster is not set.
-    esxi_hostname and cluster are mutually exclusive parameters.    
+    esxi_hostname and cluster are mutually exclusive parameters.
     This parameter is case sensitive.
 
 - **provision_vm_datacenter** (string):
@@ -71,7 +71,7 @@ N/A
     This parameter is case sensitive.
     If multiple machines are found with same name, this parameter is used to identify
     uniqueness of the virtual machine.
-  
+
 - **provision_vm_datastore** (string):
     Specify datastore or datastore cluster to provision virtual machine.
     This parameter takes precedence over disk.datastore parameter.
@@ -164,7 +164,7 @@ N/A
     For supported customization operating system matrix, (see http://partnerweb.vmware.com/programs/guestOS/guest-os-customization-matrix.pdf)
     All parameters and VMware object names are case sensitive.
     Linux based OSes requires Perl package to be installed for OS customizations.
-    
+
     Element keys:
     * existing_vm:
         type: bool
@@ -306,7 +306,7 @@ N/A
     Shrinking disks is not supported.
     Removing existing disks of the virtual machine is not supported.
     Attributes disk.controller_type, disk.controller_number, disk.unit_number are used to configure multiple types of disk controllers and disks for creating or reconfiguring virtual machine.
-    
+
     Element keys:
     * size:
         description:
@@ -753,6 +753,9 @@ N/A
     - "first" ← (default)
     - "last"
 
+- **provision_vm_is_template** (bool):
+    If true, the VM will be created as a template instead of a regular VM.
+    Default: false
 
 ## Dependencies
 
@@ -770,7 +773,7 @@ Create a ``playbook.yml`` file like this:
   gather_facts: true
 
   tasks:
-    - name: Provision a VM 
+    - name: Provision a VM
       ansible.builtin.import_role:
         name: cloud.vmware_ops.provision_vm
       vars:

--- a/roles/provision_vm/defaults/main.yml
+++ b/roles/provision_vm/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+provision_vm_is_template: false

--- a/roles/provision_vm/tasks/main.yml
+++ b/roles/provision_vm/tasks/main.yml
@@ -52,4 +52,4 @@
     use_instance_uuid: "{{ provision_vm_use_instance_uuid | d(omit) }}"
     name_match: "{{ provision_vm_name_match | d(omit) }}"
 
-    is_template: false
+    is_template: "{{ provision_vm_is_template }}"


### PR DESCRIPTION
Previously, the playbook to provision a new template used the wrong variable. The option to create a template in the provision_vm role also was not exposed.

This change exposes that option but leaves the default as false to maintain the old behavior. I explicitly set this variable in the manage_vm and manage_template playbooks