### PR TITLE
Test ACA-1592 - create VM template in a folder

### DIFF
--- a/tests/integration/targets/vmware_ops_provision_vm_test/tasks/get_vm_info.yml
+++ b/tests/integration/targets/vmware_ops_provision_vm_test/tasks/get_vm_info.yml
@@ -8,6 +8,10 @@
     vm_name: "{{ vm_name }}"
   register: vm_info
 
+- name: debug vm_info
+  ansible.builtin.debug:
+    var: vm_info
+
 - name: Fail the task if the VM doesn't exist
   ansible.builtin.fail:
     msg: "Provisioned VM does not exist"

--- a/tests/integration/targets/vmware_ops_provision_vm_test/tasks/get_vm_info.yml
+++ b/tests/integration/targets/vmware_ops_provision_vm_test/tasks/get_vm_info.yml
@@ -8,10 +8,6 @@
     vm_name: "{{ vm_name }}"
   register: vm_info
 
-- name: debug vm_info
-  ansible.builtin.debug:
-    var: vm_info
-
 - name: Fail the task if the VM doesn't exist
   ansible.builtin.fail:
     msg: "Provisioned VM does not exist"

--- a/tests/integration/targets/vmware_ops_provision_vm_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_provision_vm_test/tasks/main.yml
@@ -14,28 +14,12 @@
     loop: "{{ provision_vms }}"
     ansible.builtin.include_tasks: provision_vms_with_validation.yml
 
-  - name: Turn one of the provisioned VMs into template
-    loop: "{{ provision_vms_template }}"
-    community.vmware.vmware_guest:
-      hostname: "{{ provision_vm_hostname }}"
-      username: "{{ provision_vm_username }}"
-      password: "{{ provision_vm_password }}"
-      validate_certs: "{{ provision_vm_validate_certs }}"
-      name: "{{ item.provision_vm_name }}"
-      is_template: true
-      folder: "{{ provision_vm_folder }}"
-      datacenter: "{{ provision_vm_datacenter }}"
-
-  - name: Create a VM from the template
-    loop: "{{ provision_vms_from_template }}"
-    ansible.builtin.include_tasks: provision_vms_with_validation.yml
-
   - name: Update one the provisioned VMs
     ansible.builtin.include_tasks: update_vm.yml
 
   always:
     - name: Cleanup VMs and template from the vcenter env
-      loop: "{{ provision_vms + provision_vms_template + provision_vms_from_template }}"
+      loop: "{{ provision_vms }}"
       ansible.builtin.include_tasks: cleanup_vms.yml
 
     - name: Cleanup Network

--- a/tests/integration/targets/vmware_ops_provision_vm_test/tasks/provision_vms_with_validation.yml
+++ b/tests/integration/targets/vmware_ops_provision_vm_test/tasks/provision_vms_with_validation.yml
@@ -15,6 +15,7 @@
     provision_vm_guest_id: "{{ item.provision_vm_guest_id | default(omit) }}"
     provision_vm_datastore: "{{ item.provision_vm_datastore | default(omit) }}"
     provision_vm_template: "{{ item.provision_vm_template | default(omit) }}"
+    provision_vm_is_template: "{{ item.provision_vm_is_template | default(omit) }}"
 
 - name: Run post validations for VMs creation
   block:

--- a/tests/integration/targets/vmware_ops_provision_vm_test/tasks/provision_vms_with_validation.yml
+++ b/tests/integration/targets/vmware_ops_provision_vm_test/tasks/provision_vms_with_validation.yml
@@ -45,3 +45,32 @@
       that:
         - vm_info.virtual_machines[0].datastore_url[0].name == item.provision_vm_disk[0].datastore
     when: "'provision_vm_datastore' not in item"
+
+- name: Run additional post validation for VM template
+  block:
+  - name: Get info on VM template
+    community.vmware.vmware_guest_info:
+      validate_certs: false
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter: "{{ provision_vm_datacenter }}"
+      folder: "{{ provision_vm_folder }}"
+      name: "{{ item.provision_vm_name }}"
+    register: template_info
+
+  - name: Debug template_info
+    ansible.builtin.debug:
+      var: template_info
+
+  - name: Debug item.provision_vm_is_template
+    ansible.builtin.debug:
+      var: item.provision_vm_is_template
+
+  - name: Check template
+    ansible.builtin.assert:
+      that:
+        - template_info.instance.hw_is_template == item.provision_vm_is_template
+  when:
+    - item.provision_vm_is_template is defined
+    - item.provision_vm_is_template

--- a/tests/integration/targets/vmware_ops_provision_vm_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_provision_vm_test/vars/main.yml
@@ -8,40 +8,8 @@ provision_vm_cluster: "{{ vcenter_cluster_name }}"
 provision_vm_folder: "/{{ vcenter_datacenter }}/vm/e2e-qe"
 provision_vm_datacenter: "{{ vcenter_datacenter }}"
 
-# Create VM template
-provision_vms_template:
-  - provision_vm_name: "qe-provision-vm-rhel-9"
-    provision_vm_state: "poweredoff"
-    provision_vm_cdrom:
-      - controller_number: 0
-        unit_number: 0
-        state: present
-        type: iso
-        iso_path: "{{ datastore1_rhel_9_3_iso_path }}"
-    provision_vm_networks:
-      - name: "{{ vm_network_name }}"
-        device_type: "vmxnet3"
-        mac: "00:50:56:bd:d2:9e"
-        type: "dhcp"
-    provision_vm_resource_pool: null
-    provision_vm_disk:
-      - size_gb: 50
-        type: thin
-        datastore: "datastore1"
-    provision_vm_hardware:
-      memory_mb: 2000
-      num_cpus: 4
-      boot_firmware: efi
-      secure_boot: true
-    provision_vm_guest_id: "rhel9_64Guest"
-    provision_vm_datastore: "datastore1"
-
-# Provision VMs from template
-provision_vms_from_template:
-  - provision_vm_name: "qe-provision-vm-from-template"
-    provision_vm_state: "poweredon"
-    provision_vm_template: "{{ provision_vms_template[0].provision_vm_name }}"
-    provision_vm_datastore: "datastore1"
+# VM template name
+template_name: "qe-provision-vm-template-rhel-9"
 
 provision_vms:
 # RHEL9 VM
@@ -95,6 +63,38 @@ provision_vms:
       boot_firmware: efi
       secure_boot: true
     provision_vm_guest_id: "rhel8_64Guest"
+    provision_vm_datastore: "datastore1"
+# VM template RHEL9
+  - provision_vm_name: "{{ template_name }}"
+    provision_vm_state: "poweredoff"
+    provision_vm_cdrom:
+      - controller_number: 0
+        unit_number: 0
+        state: present
+        type: iso
+        iso_path: "{{ datastore1_rhel_9_3_iso_path }}"
+    provision_vm_networks:
+      - name: "{{ vm_network_name }}"
+        device_type: "vmxnet3"
+        mac: "00:50:56:bd:d2:9e"
+        type: "dhcp"
+    provision_vm_resource_pool: null
+    provision_vm_disk:
+      - size_gb: 50
+        type: thin
+        datastore: "datastore1"
+    provision_vm_hardware:
+      memory_mb: 2000
+      num_cpus: 4
+      boot_firmware: efi
+      secure_boot: true
+    provision_vm_guest_id: "rhel9_64Guest"
+    provision_vm_datastore: "datastore1"
+    provision_vm_is_template: true
+# Provision VM from template
+  - provision_vm_name: "qe-provision-vm-from-template"
+    provision_vm_state: "poweredon"
+    provision_vm_template: "{{ template_name }}"
     provision_vm_datastore: "datastore1"
 
 vm_to_update: "{{ provision_vms[0] }}"


### PR DESCRIPTION
https://issues.redhat.com/browse/ACA-1694

The `provision_vm` role now supports creating a VM template in a folder. This PR uses this functionality in the `vmware_ops_provision_vm` integration target and checks it is working as expected