### PR TITLE
removing vm template playbook

### DIFF
--- a/changelogs/fragments/77__mm-bugfix_remove_template_playbook.yml
+++ b/changelogs/fragments/77__mm-bugfix_remove_template_playbook.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - manage_template - Removed playbook because underlying module has a bug and does not support templates

--- a/playbooks/provision_vm/manage_template.yml
+++ b/playbooks/provision_vm/manage_template.yml
@@ -1,8 +1,0 @@
----
-- name: Playbook to provision a Template on VMware
-  hosts: all
-  gather_facts: false
-
-  roles:
-    - role: cloud.vmware_ops.provision_vm
-      provision_vm_is_template: true


### PR DESCRIPTION
QE identified an issue where the vmware_guest module does not execute the `is_template` option. So this playbook does not do what is expected