### PR TITLE
Refactoring of integration tests in order to run it with AAP

### DIFF
--- a/tests/integration/targets/vmware_ops_cluster_settings_test/run.yml
+++ b/tests/integration/targets/vmware_ops_cluster_settings_test/run.yml
@@ -10,7 +10,7 @@
       tags: eco-vcenter-ci
 
     - name: Import cluster_settings role
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vmware_ops_cluster_settings_test
       tags:
         - eco-vcenter-ci

--- a/tests/integration/targets/vmware_ops_cluster_settings_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_cluster_settings_test/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Run cluster settings role on the vCenter Env
-  tags: eco-vcenter-ci
+  when: not run_on_simulator
   block:
     - name: Import common vars
       ansible.builtin.include_vars:

--- a/tests/integration/targets/vmware_ops_cluster_settings_test/vars.yml
+++ b/tests/integration/targets/vmware_ops_cluster_settings_test/vars.yml
@@ -1,4 +1,6 @@
 ---
+run_on_simulator: true
+
 cluster_settings_hostname: "127.0.0.1"
 cluster_settings_username: "test"
 cluster_settings_password: "test"

--- a/tests/integration/targets/vmware_ops_cluster_settings_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_cluster_settings_test/vars/main.yml
@@ -1,4 +1,6 @@
 ---
+run_on_simulator: false
+
 cluster_settings_hostname: "{{ vcenter_hostname }}"
 cluster_settings_username: "{{ vcenter_username }}"
 cluster_settings_password: "{{ vcenter_password }}"

--- a/tests/integration/targets/vmware_ops_content_library_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_content_library_test/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - name: Test
-  tags:
-    - eco-vcenter-ci
+  when: not run_on_simulator
   block:
     - name: Import common vars
       ansible.builtin.include_vars:

--- a/tests/integration/targets/vmware_ops_content_library_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_content_library_test/vars/main.yml
@@ -1,4 +1,6 @@
 ---
+run_on_simulator: false
+
 content_library_hostname: "{{ vcenter_hostname }}"
 content_library_username: "{{ vcenter_username }}"
 content_library_password: "{{ vcenter_password }}"

--- a/tests/integration/targets/vmware_ops_deploy_ovf_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_deploy_ovf_test/tasks/main.yml
@@ -46,8 +46,7 @@
         state: absent
 
 - name: Test
-  tags:
-    - eco-vcenter-ci
+  when: not run_on_simulator
   block:
     - name: Test Deploy OVF From Local Filesystem
       ansible.builtin.import_role:

--- a/tests/integration/targets/vmware_ops_deploy_ovf_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_deploy_ovf_test/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - name: Setup
-  tags:
-    - eco-vcenter-ci
+  when: not run_on_simulator
   block:
     - name: Import common vars
       ansible.builtin.include_vars:

--- a/tests/integration/targets/vmware_ops_deploy_ovf_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_deploy_ovf_test/vars/main.yml
@@ -1,4 +1,5 @@
 ---
+run_on_simulator: false
 vmware_deploy_ovf_test_export_dir: /tmp
 
 deploy_ovf_hostname: "{{ vcenter_hostname }}"

--- a/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/run.yml
+++ b/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/run.yml
@@ -20,7 +20,7 @@
       tags: integration-ci
 
     - name: Import esxi maintenance test
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vmware_ops_esxi_maintenance_mode_test
       tags:
         - eco-vcenter-ci

--- a/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Test esxi maintenance on simulator
-  tags: integration-ci
+  when: run_on_simulator
   block:
     - name: Enable Maintenance Mode
       ansible.builtin.include_role:
@@ -15,7 +15,7 @@
         esxi_maintenance_mode_enable: False
 
 - name: Test esxi maintenance mode on vcenter env
-  tags: eco-vcenter-ci
+  when: not run_on_simulator
   block:
     - name: Import common vars
       ansible.builtin.include_vars:

--- a/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/vars.yml
+++ b/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/vars.yml
@@ -1,4 +1,6 @@
 ---
+run_on_simulator: true
+
 esxi_maintenance_mode_hostname: "127.0.0.1"
 esxi_maintenance_mode_username: "test"
 esxi_maintenance_mode_password: "test"

--- a/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 # General vars
+run_on_simulator: false
 resource_prefix: host-maintenance 
 resource_pool_name: "{{ resource_prefix }}-pool"
 

--- a/tests/integration/targets/vmware_ops_export_vm_as_ovf_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_export_vm_as_ovf_test/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - name: Test
-  tags:
-    - eco-vcenter-ci
+  when: not run_on_simulator
   block:
     - name: Import common vars
       ansible.builtin.include_vars:

--- a/tests/integration/targets/vmware_ops_export_vm_as_ovf_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_export_vm_as_ovf_test/vars/main.yml
@@ -1,4 +1,6 @@
 ---
+run_on_simulator: false
+
 export_vm_as_ovf_hostname: "{{ vcenter_hostname }}"
 export_vm_as_ovf_username: "{{ vcenter_username }}"
 export_vm_as_ovf_password: "{{ vcenter_password }}"

--- a/tests/integration/targets/vmware_ops_manage_folder_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_manage_folder_test/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Import common vars for tests on vCenter Environment
   ansible.builtin.include_vars:
     file: ../group_vars.yml
-  tags: eco-vcenter-ci
+  when: not run_on_simulator
 
 - name: Create Folder Tree
   loop: "{{ folder_types }}"

--- a/tests/integration/targets/vmware_ops_manage_folder_test/vars.yml
+++ b/tests/integration/targets/vmware_ops_manage_folder_test/vars.yml
@@ -1,4 +1,6 @@
 ---
+run_on_simulator: true
+
 manage_folder_hostname: "127.0.0.1"
 manage_folder_username: "test"
 manage_folder_password: "test"

--- a/tests/integration/targets/vmware_ops_manage_folder_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_manage_folder_test/vars/main.yml
@@ -1,4 +1,6 @@
 ---
+run_on_simulator: false
+
 manage_folder_hostname: "{{ vcenter_hostname }}"
 manage_folder_username: "{{ vcenter_username }}"
 manage_folder_password: "{{ vcenter_password }}"

--- a/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/mock_side_effects.yml
+++ b/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/mock_side_effects.yml
@@ -2,7 +2,7 @@
 - hosts: localhost
   gather_facts: false
   vars_files:
-    - "{{ playbook_dir }}/vars/main.yml"
+    - vars.yml
   tasks:
     # the esxi ISO usually powers down new hosts when they are done
     - name: Mock ESXi Host Power Down

--- a/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/run.yml
+++ b/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/run.yml
@@ -21,7 +21,7 @@
       tags: integration-ci
 
     - name: Import provision virtual ESXi role
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vmware_ops_provision_virtual_esxi_test
       tags:
         - integration-ci

--- a/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/runme.sh
+++ b/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/runme.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+source ../init.sh
+
+# Extract the ansible_tags from integration_config.yml
+ANSIBLE_TAGS=$(awk '/ansible_tags/ {print $2}' ../../integration_config.yml)
+
+# Check if the ANSIBLE_TAGS variable is set
+if [[ -n "$ANSIBLE_TAGS" ]]; then
+  echo "ANSIBLE_TAGS is set to: $ANSIBLE_TAGS"
+  ansible-playbook run.yml --tags "$ANSIBLE_TAGS"
+else
+  echo "ANSIBLE_TAGS is not set for Eco vCenter. Running on simulator."
+  ansible-playbook mock_side_effects.yml & ansible-playbook run.yml --tags integration-ci
+fi

--- a/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Test Virtual Esxi Provisioning on Simulator
-  tags: integration-ci
+  when: run_on_simulator
   ansible.builtin.include_role:
     name: cloud.vmware_ops.provision_virtual_esxi
 
 - name: Test Virtual Esxi Provisioning on vCenter Env
-  tags: eco-vcenter-ci
+  when: not run_on_simulator
   block:
   - name: Import common vars
     ansible.builtin.include_vars:

--- a/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/vars.yml
+++ b/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/vars.yml
@@ -1,4 +1,6 @@
 ---
+run_on_simulator: true
+
 provision_virtual_esxi_hostname: "127.0.0.1"
 provision_virtual_esxi_username: "test"
 provision_virtual_esxi_password: "test"

--- a/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/vars/main.yml
@@ -1,4 +1,6 @@
 ---
+run_on_simulator: false
+
 provision_virtual_esxi_hostname: "{{ vcenter_hostname }}"
 provision_virtual_esxi_username: "{{ vcenter_username }}"
 provision_virtual_esxi_password: "{{ vcenter_password }}"

--- a/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/vars/main.yml
@@ -24,4 +24,3 @@ provision_virtual_esxi_disks:
     datastore: datastore1
 provision_virtual_esxi_memory_mb: 10000
 provision_virtual_esxi_cpus: 8
-provision_vm_datastore: "datastore1"

--- a/tests/integration/targets/vmware_ops_provision_vm_test/run.yml
+++ b/tests/integration/targets/vmware_ops_provision_vm_test/run.yml
@@ -20,7 +20,7 @@
       tags: integration-ci
 
     - name: Import provision VM role
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vmware_ops_provision_vm_test
       tags:
         - eco-vcenter-ci

--- a/tests/integration/targets/vmware_ops_provision_vm_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_provision_vm_test/tasks/main.yml
@@ -2,9 +2,10 @@
 - name: Provision VM for simulator
   ansible.builtin.import_role:
     name: cloud.vmware_ops.provision_vm
-  tags: integration-ci
+  when: run_on_simulator
 
 - name: Perform VM Lifecycle Operations in vCenter Environment
+  when: not run_on_simulator
   block:
   - name: Import common vars
     ansible.builtin.include_vars:
@@ -48,4 +49,3 @@
         switch: "{{ vswitch_name }}"
         portgroup: "{{ portgroup_name }}"
         state: absent
-  tags: eco-vcenter-ci

--- a/tests/integration/targets/vmware_ops_provision_vm_test/vars.yml
+++ b/tests/integration/targets/vmware_ops_provision_vm_test/vars.yml
@@ -1,3 +1,6 @@
+---
+run_on_simulator: true
+
 provision_vm_hostname: "127.0.0.1"
 provision_vm_username: "test"
 provision_vm_password: "test"

--- a/tests/integration/targets/vmware_ops_provision_vm_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_provision_vm_test/vars/main.yml
@@ -1,4 +1,6 @@
 # vars.yaml
+run_on_simulator: false
+
 provision_vm_hostname: "{{ vcenter_hostname }}"
 provision_vm_username: "{{ vcenter_username }}"
 provision_vm_password: "{{ vcenter_password }}"

--- a/tests/integration/targets/vmware_ops_snapshot_management_test/run.yml
+++ b/tests/integration/targets/vmware_ops_snapshot_management_test/run.yml
@@ -15,12 +15,12 @@
       tags: integration-ci
 
     - name: Vcsim
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: prepare_soap
       tags: integration-ci
 
     - name: Import manage VM snapshot role
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vmware_ops_snapshot_management_test
       tags:
         - eco-vcenter-ci

--- a/tests/integration/targets/vmware_ops_snapshot_management_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_snapshot_management_test/tasks/main.yml
@@ -4,9 +4,10 @@
   ignore_errors: true
   ansible.builtin.import_role:
     name: cloud.vmware_ops.snapshot_management
-  tags: integration-ci
+  when: run_on_simulator
 
 - name: Test VM snapshot management role in vCenter Environment
+  when: not run_on_simulator
   block:
     - name: Import common vars
       ansible.builtin.include_vars:
@@ -49,4 +50,3 @@
       vars:
         provision_vm_state: absent
         provision_vm_force: true
-  tags: eco-vcenter-ci

--- a/tests/integration/targets/vmware_ops_snapshot_management_test/tasks/manage_snapshot.yml
+++ b/tests/integration/targets/vmware_ops_snapshot_management_test/tasks/manage_snapshot.yml
@@ -1,6 +1,6 @@
 - name: Manage snapshot of existing VM
   ansible.builtin.import_role:
-    name: snapshot_management
+    name: cloud.vmware_ops.snapshot_management
   vars:
     snapshot_management_vm_name: "{{ item.snapshot_management_vm_name | default(omit) }}"
     snapshot_management_state: "{{ item.snapshot_management_state | default(omit) }}"

--- a/tests/integration/targets/vmware_ops_snapshot_management_test/tasks/remove_snapshot.yml
+++ b/tests/integration/targets/vmware_ops_snapshot_management_test/tasks/remove_snapshot.yml
@@ -1,6 +1,6 @@
 - name: Remove snapshot {{ item.snapshot_management_new_snapshot_name }}
   ansible.builtin.include_role:
-    name: snapshot_management
+    name: cloud.vmware_ops.snapshot_management
   vars:
     snapshot_management_vm_name: "{{ item.snapshot_management_vm_name }}"
     snapshot_management_snapshot_name: "{{ item.snapshot_management_new_snapshot_name }}"

--- a/tests/integration/targets/vmware_ops_snapshot_management_test/vars.yml
+++ b/tests/integration/targets/vmware_ops_snapshot_management_test/vars.yml
@@ -1,11 +1,14 @@
-    snapshot_management_hostname: "127.0.0.1"
-    snapshot_management_username: "test"
-    snapshot_management_password: "test"
-    snapshot_management_validate_certs: false
-    snapshot_management_folder: "/DC0/vm"
-    snapshot_management_datacenter: "DC0"
-    snapshot_management_vm_name: "DC0_H0_VM0"
-    snapshot_management_port: "8989"
-    snapshot_management_state: present
-    snapshot_management_snapshot_name: "snap1"
-    snapshot_management_snapshot_description: "snap1_description"
+---
+run_on_simulator: true
+
+snapshot_management_hostname: "127.0.0.1"
+snapshot_management_username: "test"
+snapshot_management_password: "test"
+snapshot_management_validate_certs: false
+snapshot_management_folder: "/DC0/vm"
+snapshot_management_datacenter: "DC0"
+snapshot_management_vm_name: "DC0_H0_VM0"
+snapshot_management_port: "8989"
+snapshot_management_state: present
+snapshot_management_snapshot_name: "snap1"
+snapshot_management_snapshot_description: "snap1_description"

--- a/tests/integration/targets/vmware_ops_snapshot_management_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_snapshot_management_test/vars/main.yml
@@ -1,4 +1,6 @@
 # vars.yaml
+run_on_simulator: false
+
 snapshot_management_hostname: "{{ vcenter_hostname }}"
 snapshot_management_username: "{{ vcenter_username }}"
 snapshot_management_password: "{{ vcenter_password }}"

--- a/tests/integration/targets/vmware_ops_vcenter_host_connection_test/run.yml
+++ b/tests/integration/targets/vmware_ops_vcenter_host_connection_test/run.yml
@@ -25,7 +25,7 @@
       tags: integration-ci
 
     - name: Import vcenter_host_connection_test
-      ansible.builtin.include_role:
+      ansible.builtin.import_role:
         name: vmware_ops_vcenter_host_connection_test
       tags:
         - eco-vcenter-ci

--- a/tests/integration/targets/vmware_ops_vcenter_host_connection_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_vcenter_host_connection_test/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Test vCenter host connection role on vCenter env
-  tags: eco-vcenter-ci
+  when: not run_on_simulator 
   block:
     - name: Import common vars
       ansible.builtin.include_vars:
@@ -89,7 +89,7 @@
         required_state: absent
 
 - name: Test vCenter host connection role on simulator
-  tags: integration-ci
+  when: run_on_simulator
   block:
     - name: Add ESXI Host to vCenter Cluster
       ansible.builtin.import_role:

--- a/tests/integration/targets/vmware_ops_vcenter_host_connection_test/vars.yml
+++ b/tests/integration/targets/vmware_ops_vcenter_host_connection_test/vars.yml
@@ -1,4 +1,6 @@
 ---
+run_on_simulator: true
+
 vcenter_host_connection_hostname: "127.0.0.1"
 vcenter_host_connection_username: "test"
 vcenter_host_connection_password: "test"

--- a/tests/integration/targets/vmware_ops_vcenter_host_connection_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_vcenter_host_connection_test/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 # General
+run_on_simulator: false
 resource_pool_name: "host-connection-test-pool"
 
 # Vars for cloud.vmware_ops.provision_virtual_esxi role

--- a/tools/prepare_symlinks.yml
+++ b/tools/prepare_symlinks.yml
@@ -18,4 +18,5 @@
       loop: "{{ target_dirs.files }}"
       when:
         - item.path | basename | regex_search('^vmware_ops_')
+        # the test is excluded because it has a unique runme.sh created manually
         - not item.path | basename | regex_search('vmware_ops_provision_virtual_esxi_test')

--- a/tools/prepare_symlinks.yml
+++ b/tools/prepare_symlinks.yml
@@ -16,6 +16,6 @@
         mode: '0755'
         force: true
       loop: "{{ target_dirs.files }}"
-      when: 
+      when:
         - item.path | basename | regex_search('^vmware_ops_')
         - not item.path | basename | regex_search('vmware_ops_provision_virtual_esxi_test')

--- a/tools/prepare_symlinks.yml
+++ b/tools/prepare_symlinks.yml
@@ -16,4 +16,6 @@
         mode: '0755'
         force: true
       loop: "{{ target_dirs.files }}"
-      when: item.path | basename | regex_search('^vmware_ops_')
+      when: 
+        - item.path | basename | regex_search('^vmware_ops_')
+        - not item.path | basename | regex_search('vmware_ops_provision_virtual_esxi_test')


### PR DESCRIPTION
Jira ticket - [ACA-1702](https://issues.redhat.com/browse/ACA-1702)

Refactoring of integration tests in order to run it with AAP:
- added `run_on_simulator` var
- fixed import in `vmware_ops_snapshot_management_test`
- replaced `ansible.builtin.include_role` with `ansible.builtin.import_role`
- removed `provision_vm_datastore` var from `vmware_ops_provision_virtual_esxi_test`
- added `mock_side_effects.yml` to the `vmware_ops_provision_virtual_esxi_test` simulator run