### PR TITLE
Improve vmware_ops integration tests cleanup implementation

### DIFF
--- a/tests/integration/targets/runme.sh
+++ b/tests/integration/targets/runme.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 source ../init.sh
 
+# Generates a string starting with 'test-' followed by 4 random lowercase characters
+TINY_PREFIX="test-$(uuidgen | tr -d '-' | cut -c1-4 | tr '[:upper:]' '[:lower:]')"
+
 # Extract the ansible_tags from integration_config.yml
 ANSIBLE_TAGS=$(awk '/ansible_tags/ {print $2}' ../../integration_config.yml)
 
 # Check if the ANSIBLE_TAGS variable is set
 if [[ -n "$ANSIBLE_TAGS" ]]; then
   echo "ANSIBLE_TAGS is set to: $ANSIBLE_TAGS"
-  exec ansible-playbook run.yml --tags "$ANSIBLE_TAGS"
+  exec ansible-playbook run.yml --tags "$ANSIBLE_TAGS" --extra-vars "tiny_prefix=$TINY_PREFIX"
 else
   echo "ANSIBLE_TAGS is not set for Eco vCenter. Running on simulator."
   exec ansible-playbook run.yml --tags integration-ci

--- a/tests/integration/targets/vmware_ops_cluster_settings_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_cluster_settings_test/tasks/main.yml
@@ -73,3 +73,7 @@
         cluster_name: "{{ cluster_settings_cluster_name }}"
         state: absent
         validate_certs: false
+      retries: 5
+      delay: 5
+      register: result
+      until: result.failed == false

--- a/tests/integration/targets/vmware_ops_cluster_settings_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_cluster_settings_test/vars/main.yml
@@ -6,7 +6,7 @@ cluster_settings_username: "{{ vcenter_username }}"
 cluster_settings_password: "{{ vcenter_password }}"
 cluster_settings_validate_certs: false
 cluster_settings_port: "{{ vcenter_port }}"
-cluster_settings_cluster_name: "Test-Cluster"
+cluster_settings_cluster_name: "{{ tiny_prefix }}-Test-Cluster"
 cluster_settings_datacenter_name: "{{ vcenter_datacenter }}"
 
 # DPM

--- a/tests/integration/targets/vmware_ops_content_library_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_content_library_test/tasks/main.yml
@@ -28,10 +28,19 @@
 
   always:
     - name: Destroy Content Library
-      ansible.builtin.import_role:
-        name: cloud.vmware_ops.content_library
-      vars:
-        content_library_state: absent
+      community.vmware.vmware_content_library_manager:
+        hostname: "{{ content_library_hostname }}"
+        username: "{{ content_library_username }}"
+        password: "{{ content_library_password }}"
+        validate_certs: "{{ content_library_validate_certs }}"
+        library_name: "{{ content_library_name }}"
+        library_type: "{{ content_library_type }}"
+        datastore_name: "{{ content_library_datastore_name }}"
+        state: absent
+      retries: 5
+      delay: 5
+      register: result
+      until: result.failed == false
 
     - name: Get content libraries info
       ansible.builtin.import_tasks: get_content_library_info.yml

--- a/tests/integration/targets/vmware_ops_content_library_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_content_library_test/vars/main.yml
@@ -9,5 +9,5 @@ content_library_datacenter_name: "{{ vcenter_datacenter }}"
 
 content_library_datastore_name: "datastore3"
 content_library_type: local
-content_library_name: eco-vcenter-ci-vmware-content-library-test
+content_library_name: "{{ tiny_prefix }}-eco-vcenter-ci-vmware-content-library-test"
 content_library_description: "Test content library"

--- a/tests/integration/targets/vmware_ops_deploy_ovf_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_deploy_ovf_test/tasks/main.yml
@@ -82,6 +82,10 @@
       loop:
         - "{{ vm_name_local_ovf }}"
         - "{{ vm_name_content_library }}"
+      retries: 5
+      delay: 5
+      register: result
+      until: result.failed == false
 
     - name: Delete OVF On Local Filesystem
       ansible.builtin.file:
@@ -97,3 +101,7 @@
         library_name: "{{ ovf_library }}"
         library_type: local
         state: absent
+      retries: 5
+      delay: 5
+      register: result
+      until: result.failed == false

--- a/tests/integration/targets/vmware_ops_deploy_ovf_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_deploy_ovf_test/vars/main.yml
@@ -14,16 +14,16 @@ deploy_ovf_power_on: true
 
 vm_power_status: "{{ 'poweredOn' if deploy_ovf_power_on else 'poweredOff' }}"
 
-test_vm_name: deploy-ovf-vm
+test_vm_name: "{{ tiny_prefix }}-deploy-ovf-vm"
 test_vm_hardware:
   memory_mb: 2000
   num_cpus: 2
 
-ovf_library: deploy-ovf-test-library
-ovf_library_item_name: deploy-ovf-test-template
+ovf_library: "{{ tiny_prefix }}-deploy-ovf-test-library"
+ovf_library_item_name: "{{ tiny_prefix }}-deploy-ovf-test-template"
 
-vm_name_local_ovf: deploy-ovf-test-from-local-ovf
+vm_name_local_ovf: "{{ tiny_prefix }}-deploy-ovf-test-from-local-ovf"
 ovf_template_local: "{{ vmware_deploy_ovf_test_export_dir }}/{{ test_vm_name }}/{{ test_vm_name }}.ovf"
 
-vm_name_content_library: deploy-ovf-test-from-content-library
+vm_name_content_library: "{{ tiny_prefix }}-deploy-ovf-test-from-content-library"
 ovf_template_content_library: "{{ ovf_library_item_name }}"

--- a/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/tasks/add_or_remove_resource_pool.yml
+++ b/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/tasks/add_or_remove_resource_pool.yml
@@ -10,3 +10,7 @@
     validate_certs: "{{ provision_virtual_esxi_validate_certs }}"
     resource_pool: "{{ resource_pool_name }}"
     state: "{{ state }}"
+  retries: 5
+  delay: 5
+  register: result
+  until: result.failed == false

--- a/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/tasks/main.yml
@@ -124,12 +124,22 @@
         success_msg: "ESXI host is out of maintenance mode"
 
   always:
-    - name: Remove ESXI Host From vCenter Cluster
-      ansible.builtin.import_role:
-        name: cloud.vmware_ops.vcenter_host_connection
-      vars:
-        vcenter_host_connection_state: absent
-        vcenter_host_connection_esxi_hostname: "{{ _esxi_host_check.instance.ipv4 | default('') }}"
+    - name: Remove ESXI Host from vCenter Cluster to cleanup env
+      community.vmware.vmware_host:
+        hostname: "{{ vcenter_host_connection_hostname }}"
+        username: "{{ vcenter_host_connection_username }}"
+        password: "{{ vcenter_host_connection_password }}"
+        datacenter: "{{ vcenter_host_connection_datacenter }}"
+        cluster: "{{ vcenter_host_connection_cluster }}"
+        validate_certs: "{{ vcenter_host_connection_validate_certs }}"
+        esxi_hostname: "{{ _esxi_host_check.instance.ipv4 | default('') }}"
+        esxi_username: "{{ vcenter_host_connection_esxi_username }}"
+        esxi_password: "{{ vcenter_host_connection_esxi_password }}"
+        state: absent
+      retries: 5
+      delay: 5
+      register: result
+      until: result.failed == false
 
     - name: Cleanup Virtual Esxi
       ansible.builtin.include_role:

--- a/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 # General vars
 run_on_simulator: false
-resource_prefix: host-maintenance 
-resource_pool_name: "{{ resource_prefix }}-pool"
+
+resource_pool_name: "{{ tiny_prefix }}-host-maintenance-pool"
 
 # Vars for cloud.vmware_ops.provision_virtual_esxi role
 provision_virtual_esxi_hostname: "{{ vcenter_hostname }}"
@@ -16,7 +16,7 @@ provision_virtual_esxi_folder: ""
 provision_virtual_esxi_resource_pool: "{{ resource_pool_name }}"
 provision_virtual_esxi_datastore_iso_path: "{{ custom_esxi_8_iso_path }}"
 provision_virtual_esxi_vms:
-  - name: ci-vcenter-maintenance-test
+  - name: "{{ tiny_prefix }}-vm-esxi_maintenance-test"
 provision_virtual_esxi_networks:
     - name: "{{ test_network_name }}"
       device_type: "vmxnet3"

--- a/tests/integration/targets/vmware_ops_export_vm_as_ovf_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_export_vm_as_ovf_test/tasks/main.yml
@@ -47,6 +47,10 @@
         validate_certs: false
         name: "{{ export_vm_as_ovf_vm_name }}"
         state: absent
+      retries: 5
+      delay: 5
+      register: result
+      until: result.failed == false
 
     - name: Delete Exported OVF
       ansible.builtin.file:

--- a/tests/integration/targets/vmware_ops_export_vm_as_ovf_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_export_vm_as_ovf_test/vars/main.yml
@@ -8,4 +8,4 @@ export_vm_as_ovf_validate_certs: false
 export_vm_as_ovf_datacenter_name: "{{ vcenter_datacenter }}"
 
 export_vm_as_ovf_export_dir: /tmp/export_vm_as_ovf
-export_vm_as_ovf_vm_name: export-vm-as-ovf-test
+export_vm_as_ovf_vm_name: "{{ tiny_prefix }}-export-vm-as-ovf-test"

--- a/tests/integration/targets/vmware_ops_manage_folder_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_manage_folder_test/tasks/main.yml
@@ -1,64 +1,65 @@
 ---
-- name: Import common vars for tests on vCenter Environment
-  ansible.builtin.include_vars:
-    file: ../group_vars.yml
-  when: not run_on_simulator
-
-- name: Create Folder Tree
-  loop: "{{ folder_types }}"
-  ansible.builtin.include_role:
-    name: cloud.vmware_ops.manage_folder
-  vars:
-    manage_folder_state: present
-    manage_folder_folder_name: production/foo/web
-    manage_folder_folder_type: "{{ item }}"
-
-- name: Create Folder Without Managing Full Tree
-  loop: "{{ folder_types }}"
-  ansible.builtin.include_role:
-    name: cloud.vmware_ops.manage_folder
-  vars:
-    manage_folder_state: present
-    manage_folder_folder_name: db
-    manage_folder_parent_folder: production/foo
-    manage_folder_folder_type: "{{ item }}"
-
-- name: Create A Folder With A Slash In It
-  loop: "{{ folder_types }}"
-  ansible.builtin.include_role:
-    name: cloud.vmware_ops.manage_folder
-  vars:
-    manage_folder_state: present
-    manage_folder_folder_name: security/syseng
-    manage_folder_parent_folder: production/foo
-    manage_folder_parse_name_as_path: false
-    manage_folder_folder_type: "{{ item }}"
-
-- name: Get Folder Info
-  community.vmware.vmware_folder_info:
-    hostname: "{{ manage_folder_hostname }}"
-    username: "{{ manage_folder_username }}"
-    password: "{{ manage_folder_password }}"
-    datacenter: "{{ manage_folder_datacenter_name }}"
-    port: "{{ manage_folder_port }}"
-    validate_certs: false
-  delegate_to: localhost
-  register: _folder_info
-
-- name: Check Folders Were Created
-  ansible.builtin.assert:
-    that:
-      - _folder_info.folder_info.hostFolders.subfolders.production.subfolders.foo.subfolders['web'] is defined
-      - _folder_info.folder_info.hostFolders.subfolders.production.subfolders.foo.subfolders['db'] is defined
-      - _folder_info.folder_info.hostFolders.subfolders.production.subfolders.foo.subfolders['security%2fsyseng'] is defined
-    fail_msg: Folder structure does not match expected result.
-
-- name: Run Post Test Operations
+- name: Run Manage folder tests
   block:
+    - name: Import common vars for tests on vCenter Environment
+      ansible.builtin.include_vars:
+        file: ../group_vars.yml
+      when: not run_on_simulator
+
+    - name: Create Folder Tree
+      loop: "{{ folder_types }}"
+      ansible.builtin.include_role:
+        name: cloud.vmware_ops.manage_folder
+      vars:
+        manage_folder_state: present
+        manage_folder_folder_name: production/foo/web
+        manage_folder_folder_type: "{{ item }}"
+
+    - name: Create Folder Without Managing Full Tree
+      loop: "{{ folder_types }}"
+      ansible.builtin.include_role:
+        name: cloud.vmware_ops.manage_folder
+      vars:
+        manage_folder_state: present
+        manage_folder_folder_name: db
+        manage_folder_parent_folder: production/foo
+        manage_folder_folder_type: "{{ item }}"
+
+    - name: Create A Folder With A Slash In It
+      loop: "{{ folder_types }}"
+      ansible.builtin.include_role:
+        name: cloud.vmware_ops.manage_folder
+      vars:
+        manage_folder_state: present
+        manage_folder_folder_name: security/syseng
+        manage_folder_parent_folder: production/foo
+        manage_folder_parse_name_as_path: false
+        manage_folder_folder_type: "{{ item }}"
+
+    - name: Get Folder Info
+      community.vmware.vmware_folder_info:
+        hostname: "{{ manage_folder_hostname }}"
+        username: "{{ manage_folder_username }}"
+        password: "{{ manage_folder_password }}"
+        datacenter: "{{ manage_folder_datacenter_name }}"
+        port: "{{ manage_folder_port }}"
+        validate_certs: false
+      delegate_to: localhost
+      register: _folder_info
+
+    - name: Check Folders Were Created
+      ansible.builtin.assert:
+        that:
+          - _folder_info.folder_info.hostFolders.subfolders.production.subfolders.foo.subfolders['web'] is defined
+          - _folder_info.folder_info.hostFolders.subfolders.production.subfolders.foo.subfolders['db'] is defined
+          - _folder_info.folder_info.hostFolders.subfolders.production.subfolders.foo.subfolders['security%2fsyseng'] is defined
+        fail_msg: Folder structure does not match expected result.
+
+  always:
     - name: Start Cleanup
       ansible.builtin.debug:
         msg: "Running cleanup..."
-  always:
+
     - name: Delete The Whole Tree
       loop: "{{ folder_types }}"
       ansible.builtin.include_role:

--- a/tests/integration/targets/vmware_ops_manage_folder_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_manage_folder_test/tasks/main.yml
@@ -12,7 +12,7 @@
         name: cloud.vmware_ops.manage_folder
       vars:
         manage_folder_state: present
-        manage_folder_folder_name: production/foo/web
+        manage_folder_folder_name: "{{ folder_name_pattern }}/foo/web"
         manage_folder_folder_type: "{{ item }}"
 
     - name: Create Folder Without Managing Full Tree
@@ -22,7 +22,7 @@
       vars:
         manage_folder_state: present
         manage_folder_folder_name: db
-        manage_folder_parent_folder: production/foo
+        manage_folder_parent_folder: "{{ folder_name_pattern }}/foo"
         manage_folder_folder_type: "{{ item }}"
 
     - name: Create A Folder With A Slash In It
@@ -32,7 +32,7 @@
       vars:
         manage_folder_state: present
         manage_folder_folder_name: security/syseng
-        manage_folder_parent_folder: production/foo
+        manage_folder_parent_folder: "{{ folder_name_pattern }}/foo"
         manage_folder_parse_name_as_path: false
         manage_folder_folder_type: "{{ item }}"
 
@@ -50,9 +50,9 @@
     - name: Check Folders Were Created
       ansible.builtin.assert:
         that:
-          - _folder_info.folder_info.hostFolders.subfolders.production.subfolders.foo.subfolders['web'] is defined
-          - _folder_info.folder_info.hostFolders.subfolders.production.subfolders.foo.subfolders['db'] is defined
-          - _folder_info.folder_info.hostFolders.subfolders.production.subfolders.foo.subfolders['security%2fsyseng'] is defined
+          - _folder_info.folder_info.hostFolders.subfolders[folder_name_pattern].subfolders.foo.subfolders['web'] is defined
+          - _folder_info.folder_info.hostFolders.subfolders[folder_name_pattern].subfolders.foo.subfolders['db'] is defined
+          - _folder_info.folder_info.hostFolders.subfolders[folder_name_pattern].subfolders.foo.subfolders['security%2fsyseng'] is defined
         fail_msg: Folder structure does not match expected result.
 
   always:
@@ -66,5 +66,5 @@
         name: cloud.vmware_ops.manage_folder
       vars:
         manage_folder_state: absent
-        manage_folder_folder_name: production
+        manage_folder_folder_name: "{{ folder_name_pattern }}"
         manage_folder_folder_type: "{{ item }}"

--- a/tests/integration/targets/vmware_ops_manage_folder_test/vars.yml
+++ b/tests/integration/targets/vmware_ops_manage_folder_test/vars.yml
@@ -1,5 +1,6 @@
 ---
 run_on_simulator: true
+folder_name_pattern: "production"
 
 manage_folder_hostname: "127.0.0.1"
 manage_folder_username: "test"

--- a/tests/integration/targets/vmware_ops_manage_folder_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_manage_folder_test/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 run_on_simulator: false
+folder_name_pattern: "{{ tiny_prefix }}_production"
 
 manage_folder_hostname: "{{ vcenter_hostname }}"
 manage_folder_username: "{{ vcenter_username }}"

--- a/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/runme.sh
+++ b/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/runme.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 source ../init.sh
 
+# Generates a string starting with 'test-' followed by 4 random lowercase characters
+TINY_PREFIX="test-$(uuidgen | tr -d '-' | cut -c1-4 | tr '[:upper:]' '[:lower:]')"
+
 # Extract the ansible_tags from integration_config.yml
 ANSIBLE_TAGS=$(awk '/ansible_tags/ {print $2}' ../../integration_config.yml)
 
 # Check if the ANSIBLE_TAGS variable is set
 if [[ -n "$ANSIBLE_TAGS" ]]; then
   echo "ANSIBLE_TAGS is set to: $ANSIBLE_TAGS"
-  ansible-playbook run.yml --tags "$ANSIBLE_TAGS"
+  ansible-playbook run.yml --tags "$ANSIBLE_TAGS" --extra-vars "tiny_prefix=$TINY_PREFIX"
 else
   echo "ANSIBLE_TAGS is not set for Eco vCenter. Running on simulator."
   ansible-playbook mock_side_effects.yml & ansible-playbook run.yml --tags integration-ci

--- a/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/tasks/cleanup_esxi.yml
+++ b/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/tasks/cleanup_esxi.yml
@@ -11,6 +11,7 @@
     provision_vm_datacenter: "{{ provision_virtual_esxi_datacenter }}"
     provision_vm_name: "{{ provision_virtual_esxi_vms[0].name }}"
     provision_vm_state: "poweredoff"
+  ignore_errors: true
 
 - name: Cleanup Virtual Esxi
   ansible.builtin.include_role:

--- a/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/tasks/cleanup_esxi.yml
+++ b/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/tasks/cleanup_esxi.yml
@@ -62,3 +62,7 @@
     cluster: "{{ provision_virtual_esxi_cluster }}"
     resource_pool: "{{ resource_pool_name }}"
     state: absent
+  retries: 5
+  delay: 5
+  register: result
+  until: result.failed == false

--- a/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_provision_virtual_esxi_test/vars/main.yml
@@ -10,9 +10,9 @@ provision_virtual_esxi_cluster: "{{ vcenter_cluster_name }}"
 provision_virtual_esxi_folder: "e2e-qe"
 provision_virtual_esxi_datacenter: "{{ vcenter_datacenter }}"
 provision_virtual_esxi_datastore_iso_path: "{{ custom_esxi_8_iso_path }}"
-resource_pool_name: ci-resource-pool-test
+resource_pool_name: "{{ tiny_prefix }}-ci-resource-pool-test"
 provision_virtual_esxi_vms:
-  - name: ci-esxi-test-1
+  - name: "{{ tiny_prefix }}-ci-esxi-test-1"
 provision_virtual_esxi_networks:
     - name: "{{ vm_network_name }}"
       device_type: "vmxnet3"

--- a/tests/integration/targets/vmware_ops_provision_vm_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_provision_vm_test/tasks/main.yml
@@ -49,3 +49,7 @@
         switch: "{{ vswitch_name }}"
         portgroup: "{{ portgroup_name }}"
         state: absent
+      retries: 5
+      delay: 5
+      register: result
+      until: result.failed == false

--- a/tests/integration/targets/vmware_ops_provision_vm_test/tasks/post_update_settings_validation.yml
+++ b/tests/integration/targets/vmware_ops_provision_vm_test/tasks/post_update_settings_validation.yml
@@ -22,8 +22,8 @@
 - name: "Validate updated network configuration of '{{ vm_update_name }}' VM"
   ansible.builtin.assert:
     that:
-      - vm_network_info.network_info[index].name == network.name
-      - vm_network_info.network_info[index].device_type == network.device_type
+      - vm_network_info.network_info|map(attribute='name')|list is contains network.name
+      - vm_network_info.network_info|map(attribute='device_type')|list is contains network.device_type
   loop: "{{ vm_updated_networks }}"
   loop_control:
     loop_var: network

--- a/tests/integration/targets/vmware_ops_provision_vm_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_provision_vm_test/vars/main.yml
@@ -12,7 +12,7 @@ provision_vm_datacenter: "{{ vcenter_datacenter }}"
 
 # Create VM template
 provision_vms_template:
-  - provision_vm_name: "qe-provision-vm-rhel-9"
+  - provision_vm_name: "{{ tiny_prefix }}-qe-provision-vm-rhel-9"
     provision_vm_state: "poweredoff"
     provision_vm_cdrom:
       - controller_number: 0
@@ -39,14 +39,14 @@ provision_vms_template:
 
 # Provision VMs from template
 provision_vms_from_template:
-  - provision_vm_name: "qe-provision-vm-from-template"
+  - provision_vm_name: "{{ tiny_prefix }}-qe-provision-vm-from-template"
     provision_vm_state: "poweredon"
     provision_vm_template: "{{ provision_vms_template[0].provision_vm_name }}"
     provision_vm_datastore: "datastore1"
 
 provision_vms:
   # RHEL9 VM
-  - provision_vm_name: "qe-provision-vm-rhel-9"
+  - provision_vm_name: "{{ tiny_prefix }}-qe-provision-vm-rhel-9"
     provision_vm_state: "poweredoff"
     provision_vm_cdrom:
       - controller_number: 0
@@ -71,7 +71,7 @@ provision_vms:
     provision_vm_guest_id: "rhel9_64Guest"
     provision_vm_datastore: "datastore1"
   # RHEL8 VM
-  - provision_vm_name: "qe-provision-vm-rhel-8"
+  - provision_vm_name: "{{ tiny_prefix }}-qe-provision-vm-rhel-8"
     provision_vm_state: "poweredon"
     provision_vm_cdrom:
       - controller_number: 0
@@ -101,7 +101,7 @@ vm_update_name: "{{ vm_to_update.provision_vm_name }}"
 vm_update_datastore: "{{ vm_to_update.provision_vm_datastore }}"
 
 vm_names_to_update:
-  - vm_updated_name
+  - "{{ tiny_prefix }}_vm_updated_name"
   - "{{ vm_update_name }}"
 
 vm_states:
@@ -120,7 +120,7 @@ vm_updated_hardware:
   secure_boot: true
 
 vswitch_name: vSwitch0
-portgroup_name: qe-network
+portgroup_name: "{{ tiny_prefix }}-qe-network"
 
 vm_network_to_add:
   - name: "{{ portgroup_name }}"

--- a/tests/integration/targets/vmware_ops_snapshot_management_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_snapshot_management_test/vars/main.yml
@@ -18,7 +18,7 @@ vm_snapshots:
   snapshot_management_state: present
   snapshot_management_description: "This is the second snapshot of VM {{ manage_snapshot_vm_name }}"
 
-manage_snapshot_vm_name: "manage-snapshot-vm-rhel-9"
+manage_snapshot_vm_name: "{{ tiny_prefix }}-manage-snapshot-vm-rhel-9"
 
 vm_snapshots_updated:
 - snapshot_management_snapshot_name: "{{ manage_snapshot_vm_name }}-snapshot-1"

--- a/tests/integration/targets/vmware_ops_vcenter_host_connection_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_vcenter_host_connection_test/tasks/main.yml
@@ -75,6 +75,10 @@
         esxi_username: "{{ vcenter_host_connection_esxi_username }}"
         esxi_password: "{{ vcenter_host_connection_esxi_password }}"
         state: absent
+      retries: 5
+      delay: 5
+      register: result
+      until: result.failed == false
 
     - name: Remove ESXI VM to cleanup env
       ansible.builtin.include_role:

--- a/tests/integration/targets/vmware_ops_vcenter_host_connection_test/tasks/manage_resource_pool.yml
+++ b/tests/integration/targets/vmware_ops_vcenter_host_connection_test/tasks/manage_resource_pool.yml
@@ -9,3 +9,7 @@
     cluster: "{{ provision_virtual_esxi_cluster }}"
     resource_pool: "{{ provision_virtual_esxi_resource_pool }}"
     state: "{{ required_state }}"
+  retries: 5
+  delay: 5
+  register: result
+  until: result.failed == false

--- a/tests/integration/targets/vmware_ops_vcenter_host_connection_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_vcenter_host_connection_test/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # General
 run_on_simulator: false
-resource_pool_name: "host-connection-test-pool"
+resource_pool_name: "{{ tiny_prefix }}-host-connection-test-pool"
 
 # Vars for cloud.vmware_ops.provision_virtual_esxi role
 provision_virtual_esxi_hostname: "{{ vcenter_hostname }}"
@@ -15,7 +15,7 @@ provision_virtual_esxi_folder: ""
 provision_virtual_esxi_resource_pool: "{{ resource_pool_name }}"
 provision_virtual_esxi_datastore_iso_path: "{{ custom_esxi_8_iso_path }}"
 provision_virtual_esxi_vms:
-  - name: "vm-host-connection-test"
+  - name: "{{ tiny_prefix }}-vm-host-connection-test"
 provision_virtual_esxi_networks:
   - name: "{{ test_network_name }}"
     device_type: "vmxnet3"


### PR DESCRIPTION
Jira ticket - [ACA-1695](https://issues.redhat.com/browse/ACA-1695)

Changes included (separated by commits):

- Added `retries` to eliminate random failures
- Fixed `always` block for `vmware_ops_manage_folder_test`
- Added `ignore_errors` to `cleanup_esxi.yml` of `vmware_ops_provision_virtual_esxi_test`
- Added `tiny_prefix` to isolate test runs
- Fixed assertion in `vmware_ops_provision_vm_test`
