### PR TITLE
Add missing var to template

### DIFF
--- a/changelogs/fragments/91__fix_unused_var.yml
+++ b/changelogs/fragments/91__fix_unused_var.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Added unused var `provision_vcenter_vm_network_ip_family` to template with default value of ipv4

--- a/roles/provision_vcenter/templates/config_parts/vm.j2
+++ b/roles/provision_vcenter/templates/config_parts/vm.j2
@@ -20,7 +20,7 @@
     "gateway": "{{ provision_vcenter_vm_network_gateway }}",
     "system_name": "{{ provision_vcenter_vm_network_hostname }}",
     {%- endif +%}
-    "ip_family": "ipv4",
+    "ip_family": "{{ provision_vcenter_vm_network_ip_family }}",
     "mode": "{{ provision_vcenter_vm_network_mode }}"
 },
 "os": {


### PR DESCRIPTION
Var for `provision_vcenter_vm_network_ip_family` was already defined with a default value, but was not used in the template. This PR fixes this.