### PR TITLE
add experience setup

### DIFF
--- a/extensions/experiences/README.md
+++ b/extensions/experiences/README.md
@@ -1,0 +1,17 @@
+# AAP Experiences
+
+Experiences are an easy way to create AAP resources from YAML templates to get new users up and running quickly. For example, the `vmware_ops` experience creates credentials, templates that require minimal configuration to work.
+
+## Additional Resources
+
+#### Controller Configuration
+This is the collection that actually loads the `setup.yml` into AAP.
+https://github.com/redhat-cop/controller_configuration
+
+## Loading the Experience Locally
+
+When creating the `setup.yml` that defines experience resources to create, it may be useful to load the experience from the command line.
+
+1. Install pre-req collections `ansible-galaxy collection install infra.controller_configuration awx.awx`
+2. Run the playbook, `ansible-playbook extensions/experiences/load_experience.yml`
+3. Optionally, you can load a specific experience by setting the name. For example `-e experience_name=vmware_ops`

--- a/extensions/experiences/README.md
+++ b/extensions/experiences/README.md
@@ -13,5 +13,6 @@ https://github.com/redhat-cop/controller_configuration
 When creating the `setup.yml` that defines experience resources to create, it may be useful to load the experience from the command line.
 
 1. Install pre-req collections `ansible-galaxy collection install infra.controller_configuration awx.awx`
+2. Set environment variables to connect to your instance of AAP: CONTROLLER_HOST, CONTROLLER_USERNAME, CONTROLLER_PASSWORD
 2. Run the playbook, `ansible-playbook extensions/experiences/load_experience.yml`
 3. Optionally, you can load a specific experience by setting the name. For example `-e experience_name=vmware_ops`

--- a/extensions/experiences/load_experience.yml
+++ b/extensions/experiences/load_experience.yml
@@ -1,11 +1,16 @@
 ---
-- hosts: localhost
+# We have no control over the infra collection needing the collections
+# keyword, hence the ansible-lint noqa tag below
+- name: Load An Experience Into AAP   # noqa: fqcn[keyword]
+  hosts: localhost
   gather_facts: false
-  collections:   # noqa fqcn[keyword]   We have no control over this
+  collections:
     - awx.awx
   vars:
     controller_configuration_credentials_secure_logging: false
     controller_validate_certs: false
+    controller_configuration_async_delay: 1
+    controller_configuration_async_retries: 30
     controller_hostname: "{{ lookup('env', 'CONTROLLER_HOST') }}"
     controller_username: "{{ lookup('env', 'CONTROLLER_USERNAME') }}"
     controller_password: "{{ lookup('env', 'CONTROLLER_PASSWORD') }}"
@@ -18,6 +23,3 @@
     - name: Execute automation controller resource configuration
       ansible.builtin.include_role:
         name: infra.controller_configuration.dispatch
-      vars:
-        controller_configuration_async_delay: 1
-        controller_configuration_async_retries: 30

--- a/extensions/experiences/load_experience.yml
+++ b/extensions/experiences/load_experience.yml
@@ -1,0 +1,24 @@
+---
+- hosts: localhost
+  gather_facts: false
+  environment:
+    CONTROLLER_USERNAME: "{{ lookup('env', 'CONTROLLER_USERNAME') }}"
+    CONTROLLER_PASSWORD: "{{ lookup('env', 'CONTROLLER_PASSWORD') }}"
+    CONTROLLER_HOST: "{{ lookup('env', 'CONTROLLER_HOST') }}"
+    CONTROLLER_VERIFY_SSL: false
+  collections:
+    - awx.awx
+  vars:
+    controller_configuration_credentials_secure_logging: false
+    experience_name: vmware_ops
+
+  tasks:
+    - name: Include Setup YAML
+      ansible.builtin.include_vars: "{{ playbook_dir }}/{{ experience_name }}/setup.yml"
+
+    - name: Execute automation controller resource configuration
+      ansible.builtin.include_role:
+        name: infra.controller_configuration.dispatch
+      vars:
+        controller_configuration_async_delay: 1
+        controller_configuration_async_retries: 30

--- a/extensions/experiences/load_experience.yml
+++ b/extensions/experiences/load_experience.yml
@@ -1,15 +1,14 @@
 ---
 - hosts: localhost
   gather_facts: false
-  environment:
-    CONTROLLER_USERNAME: "{{ lookup('env', 'CONTROLLER_USERNAME') }}"
-    CONTROLLER_PASSWORD: "{{ lookup('env', 'CONTROLLER_PASSWORD') }}"
-    CONTROLLER_HOST: "{{ lookup('env', 'CONTROLLER_HOST') }}"
-    CONTROLLER_VERIFY_SSL: false
-  collections:
+  collections:   # noqa fqcn[keyword]   We have no control over this
     - awx.awx
   vars:
     controller_configuration_credentials_secure_logging: false
+    controller_validate_certs: false
+    controller_hostname: "{{ lookup('env', 'CONTROLLER_HOST') }}"
+    controller_username: "{{ lookup('env', 'CONTROLLER_USERNAME') }}"
+    controller_password: "{{ lookup('env', 'CONTROLLER_PASSWORD') }}"
     experience_name: vmware_ops
 
   tasks:

--- a/extensions/experiences/vmware_ops/README.md
+++ b/extensions/experiences/vmware_ops/README.md
@@ -10,7 +10,7 @@ If the user is expected to update some resources after the experience is loaded,
 
 #### VMware Ops - vCenter Credential
 
-This is a credential for VMware vCenter. It securly holds the authentication details for your vCenter while also sharing them with the playbook as environment variables. This makes authentication seemless.
+This is a credential for VMware vCenter. It securely holds the authentication details for your vCenter while also sharing them with the playbook as environment variables. This makes authentication seamless.
 
 You must edit the credential once it has been loaded and update the values for the following attributes:
 - username

--- a/extensions/experiences/vmware_ops/README.md
+++ b/extensions/experiences/vmware_ops/README.md
@@ -1,0 +1,32 @@
+# vmware_ops Experience
+
+This experience bootstraps basic VMware resources in AAP and creates job templates that may be useful to operators. <br>
+
+If the user is expected to update some resources after the experience is loaded, it should be documented in the setup.yml user_message and here.
+
+## Created Resources
+
+### Credentials
+
+#### VMware Ops - vCenter Credential
+
+This is a credential for VMware vCenter. It securly holds the authentication details for your vCenter while also sharing them with the playbook as environment variables. This makes authentication seemless.
+
+You must edit the credential once it has been loaded and update the values for the following attributes:
+- username
+- password
+- vCenter hostname
+
+### Inventories
+
+#### VMware Ops - localhost
+
+This is a simple inventory containing only the localhost. That is generally sufficient for more vmware_ops playbooks.
+
+You can add additional connection variables, or variables you want applied to all templates, to this inventory.
+
+### Templates
+
+#### VMware Ops - Gather Info
+
+This template gathers a variety of info from vCenter. It runs the `playbooks/info.yml` playbook.

--- a/extensions/experiences/vmware_ops/setup.yml
+++ b/extensions/experiences/vmware_ops/setup.yml
@@ -1,0 +1,44 @@
+---
+user_message:
+  - Update the 'VMware Ops - vCenter Credential' credential to include your environments vCenter hostname, username, and password.
+  - Add other connection variables to the 'VMware Ops - localhost' inventory.
+
+controller_credentials:
+  - name: VMware Ops - vCenter Credential
+    credential_type: VMware vCenter
+    organization: Default
+    state: exists
+    inputs:
+      host: REPLACEME
+      username: REPLACEME
+      password: REPLACEME
+
+controller_inventories:
+  - name: VMware Ops - localhost
+    organization: Default
+    variables:
+      vcenter_validate_certs: false
+
+controller_projects:
+  - name: cloud.vmware_ops
+    scm_type: git
+    wait: true
+    scm_url: https://github.com/redhat-cop/cloud.vmware_ops.git
+    scm_clean: true
+    scm_update_on_launch: true
+    scm_update_cache_timeout: 600
+
+controller_hosts:
+  - name: localhost
+    organization: Default
+    inventory: VMware Ops - localhost
+
+controller_templates:
+  - name: VMware Ops - Gather Info
+    job_type: run
+    inventory: VMware Ops - localhost
+    project: cloud.vmware_ops
+    playbook: playbooks/info.yml
+    credentials:
+      - VMware Ops - vCenter Credential
+    survey_enabled: false


### PR DESCRIPTION
This is a basic `setup.yml` for the AAP "Experiences" which helps bootstrap example playbooks and resources for new users.

This only creates one job template because we have other tickets related to playbook naming/structure. So I think we should do those first and then add more job templates here.