### PR TITLE
use vmware.vmware.cluster_vcls instead of community

### DIFF
--- a/changelogs/fragments/97_swap_community_vcls_for_vmware.yml
+++ b/changelogs/fragments/97_swap_community_vcls_for_vmware.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cluster_settings - Use the vmware.vmware.cluster_vcls module instead of the community.vmware.vmware_cluster_vcls module

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -22,6 +22,6 @@ build_ignore:
 dependencies:
   "vmware.vmware_rest": ">=2.3.1"
   "community.vmware": ">=4.4.0"
-  "vmware.vmware": ">=1.4.0"
+  "vmware.vmware": ">=1.5.0"
   "community.general": ">=9.2.0"
   "ansible.posix": ">=1.5.4"

--- a/roles/cluster_settings/README.md
+++ b/roles/cluster_settings/README.md
@@ -4,10 +4,7 @@ A role to define cluster settings in vCenter.
 
 ## Requirements
 
-pyvmomi < 7.0.3
-
-In some cases, the vCLS cluster settings will fail to apply when using pyvmomi version 7.0.3 or greater. If this feature is required, using an earlier version will work.
-Support for version 7.0.3 and higher is planned for the next release of community.vmware (>4.4.0), at which point this restriction will be removed.
+pyvmomi
 
 ## Role Variables
 ### Auth

--- a/roles/cluster_settings/tasks/main.yml
+++ b/roles/cluster_settings/tasks/main.yml
@@ -89,7 +89,7 @@
   when: cluster_settings_ha_enable is defined
 
 - name: Configure vCLS Datastore Settings
-  community.vmware.vmware_cluster_vcls:
+  vmware.vmware.cluster_vcls:
     hostname: "{{ cluster_settings_hostname }}"
     username: "{{ cluster_settings_username }}"
     password: "{{ cluster_settings_password }}"

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -5,7 +5,6 @@ requests
 pycdlib
 ansible-core
 
-# see the cluster_settings role README.md for an explanation on the <7.0.3 restriction
-pyVmomi>=6.7,<7.0.3
+pyVmomi>=6.7
 # automation sdk >tag:8.0.2.0 requires pyVmomi 8
 git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.2.0


### PR DESCRIPTION
Replace community.vmware.vmware_cluster_vcls with vmware.vmware.cluster_vcls

This also removes the pyvmomi<7.0.3 restriction that was on the repo