### PR TITLE
replace cluster module with vmware.vmware module

### DIFF
--- a/changelogs/fragments/98_swap_community_cluster_for_vmware.yml
+++ b/changelogs/fragments/98_swap_community_cluster_for_vmware.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - cluster_settings - Use the vmware.vmware.cluster module instead of the community.vmware.vmware_cluster module
+  - cluster_settings - Use the correct module to apply DRS recommendations instead of cluster module

--- a/roles/cluster_settings/tasks/main.yml
+++ b/roles/cluster_settings/tasks/main.yml
@@ -46,7 +46,7 @@
   when: cluster_settings_drs_enable is defined
 
 - name: Apply DRS Recommendations for Cluster
-  community.vmware.vmware_cluster:
+  community.vmware.vmware_cluster_drs_recommendations:
     hostname: "{{ cluster_settings_hostname }}"
     username: "{{ cluster_settings_username }}"
     password: "{{ cluster_settings_password }}"

--- a/tests/integration/targets/vmware_ops_cluster_settings_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_cluster_settings_test/tasks/main.yml
@@ -7,7 +7,7 @@
         file: ../group_vars.yml
 
     - name: "Create New Cluster: {{ cluster_settings_cluster_name }}"
-      community.vmware.vmware_cluster:
+      vmware.vmware.cluster:
         hostname: "{{ cluster_settings_hostname }}"
         username: "{{ cluster_settings_username }}"
         password: "{{ cluster_settings_password }}"
@@ -65,7 +65,7 @@
 
   always:
     - name: "Cleanup Cluster: {{ cluster_settings_cluster_name }}"
-      community.vmware.vmware_cluster:
+      vmware.vmware.cluster:
         hostname: "{{ cluster_settings_hostname }}"
         username: "{{ cluster_settings_username }}"
         password: "{{ cluster_settings_password }}"


### PR DESCRIPTION
Replacing instances of community cluster module with vmware.vmware module

Also noticed that the cluster settings role uses the wrong module (community.vmware.vmware_cluster) to apply DRS settings, so I fixed that