### PR TITLE
deploy_ovf_template should not always be mandatory

### DIFF
--- a/changelogs/fragments/99_deploy_ovf_template_required_var.yml
+++ b/changelogs/fragments/99_deploy_ovf_template_required_var.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - deploy_ovf - Fixed the pre-check assertions for deploy_ovf_template var since it is required with content libraries and optional otherwise

--- a/roles/deploy_ovf/tasks/input_validation.yml
+++ b/roles/deploy_ovf/tasks/input_validation.yml
@@ -10,13 +10,21 @@
     quiet: true
     fail_msg: Variable must be set when using this role.
 
-- name: Check Deployment Variables
+- name: Check Non-Library OVF Deployment Variables
   ansible.builtin.assert:
     that: >-
-      (deploy_ovf_url is defined and (deploy_ovf_template is not defined and deploy_ovf_library is not defined)) or
-      (deploy_ovf_url is not defined and (deploy_ovf_template is defined or deploy_ovf_library is defined))
+      (deploy_ovf_url is defined and deploy_ovf_template is not defined) or
+      (deploy_ovf_url is not defined and deploy_ovf_template is defined)
     quiet: true
-    fail_msg: deploy_ovf_url is mutually exclusive with deploy_ovf_template and deploy_ovf_library.
+    fail_msg: One of deploy_ovf_url or deploy_ovf_template is required when deploy_ovf_library is not used.
+  when: deploy_ovf_library is not defined
+
+- name: Check Content Library Deployment Variables
+  ansible.builtin.assert:
+    that: deploy_ovf_template is defined
+    quiet: true
+    fail_msg: deploy_ovf_template is required when deploy_ovf_library is defined.
+  when: deploy_ovf_library is defined
 
 - name: Check Datastore Variables
   ansible.builtin.assert:

--- a/roles/deploy_ovf/tasks/main.yml
+++ b/roles/deploy_ovf/tasks/main.yml
@@ -15,7 +15,7 @@
     cluster: "{{ deploy_ovf_cluster_name | default(omit) }}"
 
     name: "{{ deploy_ovf_vm_name }}"
-    ovf: "{{ deploy_ovf_template }}"
+    ovf: "{{ deploy_ovf_template | default(omit) }}"
     esxi_hostname: "{{ deploy_ovf_esxi_host | default(omit) }}"
     folder: "{{ deploy_ovf_folder | default(omit) }}"
     resource_pool: "{{ deploy_ovf_resource_pool | default(omit) }}"


### PR DESCRIPTION
This makes the deploy_ovf pre-check assertions a little easier to read by breaking them up.

It also makes the deploy_ovf_template variable optional in the case that the user has set the deploy_ovf_url and is not using content libraries as a source. Previously, it was always mandatory which is not accurate