### PR TITLE
Bugfix/typos in docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+---
+repos:
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,9 +61,9 @@ Minor Changes
 - esxi_maintenance_mode - add role metadata
 - esxi_maintenance_mode test - adding the integartion test for esxi_maintenance_mode role
 - export_vm_as_ovf - add role metadata
-- export_vm_as_ovf - added role, playbook, tests to export an exisiting VM from VCenter or ESXi as an OVF
+- export_vm_as_ovf - added role, playbook, tests to export an existing VM from VCenter or ESXi as an OVF
 - export_vm_as_ovf - adding check on ovf file in integration tests for export_vm_as_ovf role
-- general change to the testing structure which duplicate runme.sh for each target instead of recreating it manaully
+- general change to the testing structure which duplicate runme.sh for each target instead of recreating it manually
 - info - add role metadata
 - info_test - adding a CI for validated content repo to run on a real vcenter env, and include this test within the pr
 - manage_folder - Added new role, tests, and playbook to create or delete a folder in VCenter
@@ -94,9 +94,9 @@ Minor Changes
 - add_esxi_host_to_vcenter - Added new playbook to add an ESXi host to a vCenter
 - cluster_settings - Added new playbook to modify cluster settings
 - cluster_settings - Added new role for managing different cluster settings including DRM, DRS, vCLS, HA, and vSAN. Added integration tests for role
-- disable_high_availability - Added playbook to disable high availbility in  a vcenter cluster
+- disable_high_availability - Added playbook to disable high availability in  a vcenter cluster
 - disable_maintenance_mode - Added new playbook to disable maintenance mode on an ESXi host
-- enable_high_availability - Added playbook to enable and configure high availbility in a vcenter cluster
+- enable_high_availability - Added playbook to enable and configure high availability in a vcenter cluster
 - enable_maintenance_mode - Added new playbook to enable maintenance mode on an ESXi host
 - esxi_maintenance_mode - Added new role for setting an ESXi host's maintenance mode status. Added integration tests for role
 - info - Fix creation of temporary files

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -35,11 +35,11 @@ releases:
       - cluster_settings - Added new playbook to modify cluster settings
       - cluster_settings - Added new role for managing different cluster settings
         including DRM, DRS, vCLS, HA, and vSAN. Added integration tests for role
-      - disable_high_availability - Added playbook to disable high availbility in  a
+      - disable_high_availability - Added playbook to disable high availability in  a
         vcenter cluster
       - disable_maintenance_mode - Added new playbook to disable maintenance mode
         on an ESXi host
-      - enable_high_availability - Added playbook to enable and configure high availbility
+      - enable_high_availability - Added playbook to enable and configure high availability
         in a vcenter cluster
       - enable_maintenance_mode - Added new playbook to enable maintenance mode on
         an ESXi host
@@ -108,12 +108,12 @@ releases:
       - esxi_maintenance_mode test - adding the integartion test for esxi_maintenance_mode
         role
       - export_vm_as_ovf - add role metadata
-      - export_vm_as_ovf - added role, playbook, tests to export an exisiting VM from
+      - export_vm_as_ovf - added role, playbook, tests to export an existing VM from
         VCenter or ESXi as an OVF
       - export_vm_as_ovf - adding check on ovf file in integration tests for export_vm_as_ovf
         role
       - general change to the testing structure which duplicate runme.sh for each
-        target instead of recreating it manaully
+        target instead of recreating it manually
       - info - add role metadata
       - info_test - adding a CI for validated content repo to run on a real vcenter
         env, and include this test within the pr

--- a/changelogs/fragments/104-fix-typos-and-grammar-in-docs.yml
+++ b/changelogs/fragments/104-fix-typos-and-grammar-in-docs.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fixed typos and grammatical errors in documentation, task names, and changelogs

--- a/playbooks/esxi_management/add_esxi_host_to_vcenter.yml
+++ b/playbooks/esxi_management/add_esxi_host_to_vcenter.yml
@@ -1,5 +1,5 @@
 ---
-- name: Playbook To Add An ESXI Host To VCenter
+- name: Playbook To Add An ESXi Host To VCenter
   hosts: all
   gather_facts: false
 

--- a/playbooks/esxi_management/disable_maintenance_mode.yml
+++ b/playbooks/esxi_management/disable_maintenance_mode.yml
@@ -1,5 +1,5 @@
 ---
-- name: Playbook To Remove An ESXI Host From Maintenance Mode
+- name: Playbook To Remove An ESXi Host From Maintenance Mode
   hosts: all
   gather_facts: false
 

--- a/playbooks/esxi_management/enable_maintenance_mode.yml
+++ b/playbooks/esxi_management/enable_maintenance_mode.yml
@@ -1,5 +1,5 @@
 ---
-- name: Playbook To Put An ESXI Host In Maintenance Mode
+- name: Playbook To Put An ESXi Host In Maintenance Mode
   hosts: all
   gather_facts: false
 

--- a/playbooks/esxi_management/reconnect_esxi_host_in_vcenter.yml
+++ b/playbooks/esxi_management/reconnect_esxi_host_in_vcenter.yml
@@ -1,5 +1,5 @@
 ---
-- name: Playbook To Reconnect An ESXI Host In VCenter
+- name: Playbook To Reconnect An ESXi Host In VCenter
   hosts: all
   gather_facts: false
 

--- a/playbooks/esxi_management/remove_esxi_host_from_vcenter.yml
+++ b/playbooks/esxi_management/remove_esxi_host_from_vcenter.yml
@@ -1,5 +1,5 @@
 ---
-- name: Playbook To Remove An ESXI Host From VCenter
+- name: Playbook To Remove An ESXi Host From VCenter
   hosts: all
   gather_facts: false
 

--- a/playbooks/info.yml
+++ b/playbooks/info.yml
@@ -1,4 +1,4 @@
-- name: Gather infomation about VMware
+- name: Gather information about VMware
   hosts: all
   gather_facts: false
 

--- a/roles/cluster_settings/README.md
+++ b/roles/cluster_settings/README.md
@@ -27,7 +27,7 @@ N/A
   - The name of the datacenter in vSphere vCenter which contains the cluster to configure.
 
 - **cluster_settings_port**:
-  - str or int, The port to use to authenticate to the vSphere vCenter which contains the cluster to configure.
+  - str or int, The port used to authenticate to the vSphere vCenter that contains the cluster to configure.
 
 ### Cluster settings
 
@@ -83,7 +83,7 @@ N/A
   - str, State of virtual machine health monitoring service. One of `vmAndAppMonitoring`, `vmMonitoringDisabled`, `vmMonitoringOnly`
 
 - **cluster_settings_ha_host_isolation_response**:
-  - str, Indicates whether or VMs should be powered off if a host determines that it is isolated from the rest of the compute resource. One of `none`, `powerOff`, `powerOn`
+  - str, Indicates whether VMs should be powered off if a host determines that it is isolated from the rest of the compute resource. One of `none`, `powerOff`, `powerOn`
 
 - **cluster_settings_ha_slot_based_admission_control**:
   - dict, Configure slot based admission control policy.

--- a/roles/cluster_settings/README.md
+++ b/roles/cluster_settings/README.md
@@ -2,9 +2,9 @@
 
 A role to define cluster settings in vCenter.
 
-## Requirements
+## Dependencies
 
-pyvmomi
+N/A
 
 ## Role Variables
 ### Auth
@@ -136,7 +136,7 @@ pyvmomi
   - Used only when `cluster_settings_ha_apd_response` is `restartConservative` or `restartAggressive`.
 
 - **cluster_settings_ha_pdl_response**:
-  - str, VM storage protection setting for storage failures categorized as Permenant Device Loss (PDL).
+  - str, VM storage protection setting for storage failures categorized as Permanent Device Loss (PDL).
   - Options are `disabled`, `warning`, `restartAggressive`
 
 
@@ -169,10 +169,6 @@ pyvmomi
   - str, The port of a proxy host that should be used for all HTTPs communication by the role. Optional
 
 
-## Dependencies
-
-- vmware.vmware_rest
-
 ## Example Playbook
 ```yaml
 ---
@@ -187,7 +183,7 @@ pyvmomi
 
 GNU General Public License v3.0 or later
 
-See [LICENCE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
+See [LICENSE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
 
 ## Author Information
 

--- a/roles/content_library/README.md
+++ b/roles/content_library/README.md
@@ -1,8 +1,8 @@
 # content_library
 
-A role to manage VMWare content libaries. You can create or delete both local and subscribed content libraries.
+A role to manage VMWare content libraries. You can create or delete both local and subscribed content libraries.
 
-## Requirements
+## Dependencies
 
 N/A
 
@@ -63,10 +63,6 @@ N/A
   - str, The port of a proxy host that should be used for all HTTPs communication by the role. Optional
 
 
-## Dependencies
-
-- community.vmware
-
 ## Example Playbook
 ```yaml
 ---
@@ -89,7 +85,7 @@ N/A
 
 GNU General Public License v3.0 or later
 
-See [LICENCE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
+See [LICENSE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
 
 ## Author Information
 

--- a/roles/content_library/README.md
+++ b/roles/content_library/README.md
@@ -27,7 +27,7 @@ N/A
   - The name of the datacenter in vSphere vCenter which contains the cluster to configure.
 
 - **content_library_port**:
-  - str or int, The port to use to authenticate to the vSphere vCenter which contains the cluster to configure.
+  - str or int, The port used to authenticate to the vSphere vCenter that contains the cluster to configure.
 
 ### Library
 - **content_library_datastore_name**:
@@ -46,7 +46,7 @@ N/A
   - str, `local` or `subscribed`. Controls if the library will be hosted locally or should subscribe to a remote library
 
 #### Subscribed Library Settings
-- **content_library_ssl_thumbrpint**:
+- **content_library_ssl_thumbprint**:
   - str, The SSL thumbprint of the content library you want to which you want to subscribe.
 
 - **content_library_subscription_url**:

--- a/roles/deploy_ovf/README.md
+++ b/roles/deploy_ovf/README.md
@@ -2,31 +2,31 @@
 
 A role to deploy a VM from an OVF file. The OVF can be located on the `ansible_host` filesystem, at a URL, or located in a content library.
 
-## Requirements
+## Dependencies
 
 N/A
 
 ## Role Variables
 ### Auth
 - **deploy_ovf_username**:
-  - str, Required. The vSphere vCenter or ESXI host username.
+  - str, Required. The vSphere vCenter or ESXi host username.
 
 - **deploy_ovf_password**:
-  - str, Required. The vSphere vCenter or ESXI host password.
+  - str, Required. The vSphere vCenter or ESXi host password.
 
 - **deploy_ovf_hostname**:
-  - str, Required. The hostname or IP address of the vSphere vCenter or ESXI host.
+  - str, Required. The hostname or IP address of the vSphere vCenter or ESXi host.
 
 - **deploy_ovf_validate_certs**
   - bool, Allows connection when SSL certificates are not valid. Set to false when certificates are not trusted.
 
 - **deploy_ovf_port**:
-  - str or int, The port to use to authenticate to the vSphere vCenter or ESXI host.
+  - str or int, The port to use to authenticate to the vSphere vCenter or ESXi host.
 
 
 ### Placement
 - **deploy_ovf_cluster_name**:
-  - str, The name of the cluster in vSphere vCenter to configure. Required if your connecting to a vcenter cluster and `deploy_ovf_esxi_host` is not provided.
+  - str, The name of the cluster in vSphere vCenter to configure. Required if your connecting to a vCenter cluster and `deploy_ovf_esxi_host` is not provided.
 
 - **deploy_ovf_datacenter_name**:
   - str, Required. The name of the datacenter in vSphere vCenter where the virtual machine should be deployed.
@@ -117,9 +117,6 @@ N/A
 - **deploy_ovf_proxy_port**:
   - str, The port of a proxy host that should be used for all HTTPs communication by the role. Optional
 
-## Dependencies
-
-- community.vmware
 
 ## Example Playbook
 ```yaml
@@ -174,7 +171,7 @@ N/A
 
 GNU General Public License v3.0 or later
 
-See [LICENCE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
+See [LICENSE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
 
 ## Author Information
 

--- a/roles/deploy_ovf/README.md
+++ b/roles/deploy_ovf/README.md
@@ -21,12 +21,12 @@ N/A
   - bool, Allows connection when SSL certificates are not valid. Set to false when certificates are not trusted.
 
 - **deploy_ovf_port**:
-  - str or int, The port to use to authenticate to the vSphere vCenter or ESXi host.
+  - str or int, The port used to authenticate to the vSphere vCenter that contains the cluster to configure.
 
 
 ### Placement
 - **deploy_ovf_cluster_name**:
-  - str, The name of the cluster in vSphere vCenter to configure. Required if your connecting to a vCenter cluster and `deploy_ovf_esxi_host` is not provided.
+  - str, The name of the cluster in vSphere vCenter to configure. Required if you are connecting to a vCenter cluster and `deploy_ovf_esxi_host` is not provided.
 
 - **deploy_ovf_datacenter_name**:
   - str, Required. The name of the datacenter in vSphere vCenter where the virtual machine should be deployed.
@@ -148,7 +148,7 @@ N/A
       deploy_ovf_datacenter_name: DC1
       deploy_ovf_cluster_name: CL1
       deploy_ovf_vm_name: test-vm
-      deploy_ovf_libarary: my-content-library
+      deploy_ovf_library: my-content-library
       deploy_ovf_template: my-ovf-template
       deploy_ovf_datastore: datastore1
 

--- a/roles/deploy_ovf/README.md
+++ b/roles/deploy_ovf/README.md
@@ -21,7 +21,7 @@ N/A
   - bool, Allows connection when SSL certificates are not valid. Set to false when certificates are not trusted.
 
 - **deploy_ovf_port**:
-  - str or int, The port used to authenticate to the vSphere vCenter that contains the cluster to configure.
+  - str or int, The port used to authenticate to the vSphere vCenter or ESXi host.
 
 
 ### Placement

--- a/roles/esxi_maintenance_mode/README.md
+++ b/roles/esxi_maintenance_mode/README.md
@@ -1,28 +1,28 @@
 # esxi_maintenance_mode
 
-Either put an ESXI host in maintenance mode or take the host out of maintenance mode.
+Either put an ESXi host in maintenance mode or take the host out of maintenance mode.
 
-## Requirements
+## Dependencies
 
-pyvomi
+N/A
 
 ## Role Variables
 
 ### Auth
 - **esxi_maintenance_mode_hostname**:
-  - str, The hostname of the esxi or vcenter on which you want to deploy the application. Required.
+  - str, The hostname of the ESXi or vCenter on which you want to deploy the application. Required.
 
 - **esxi_maintenance_mode_username**:
-  - str, The username to use to authenticate to the esxi or vcenter on which you want to deploy the application. Required.
+  - str, The username to use to authenticate to the ESXi or vCenter on which you want to deploy the application. Required.
 
 - **esxi_maintenance_mode_password**:
-  - str, The password to use to authenticate to the esxi or vcenter on which you want to deploy the application. Required.
+  - str, The password to use to authenticate to the ESXi or vCenter on which you want to deploy the application. Required.
 
 - **esxi_maintenance_mode_port**:
-  - str or int, The port to use to authenticate to the esxi or vcenter on which you want to deploy the application. Required.
+  - str or int, The port to use to authenticate to the ESXi or vCenter on which you want to deploy the application. Required.
 
 - **esxi_maintenance_mode_validate_certs**:
-  - bool, If true then certificates will be validated when connecting to the esxi or vcenter for auth. Optional.
+  - bool, If true then certificates will be validated when connecting to the ESXi or vCenter for auth. Optional.
 
 ### Proxy Options
 
@@ -34,14 +34,14 @@ pyvomi
 
 ### Other Options
 - **esxi_maintenance_mode_enable**:
-  - bool, If true the ESXI host will be put into maintenance mode. If false, the host will be taken out of maintenance mode
+  - bool, If true the ESXi host will be put into maintenance mode. If false, the host will be taken out of maintenance mode
   - Default value is True
 
 - **esxi_maintenance_mode_esxi_hostname**:
-  - str, The hostname of the ESXI host that you want to manage. Required
+  - str, The hostname of the ESXi host that you want to manage. Required
 
 - **esxi_maintenance_mode_evacuate**:
-  - bool, If true, powered off VMs on the ESXI host will be evacuated.
+  - bool, If true, powered off VMs on the ESXi host will be evacuated.
 
 - **esxi_maintenance_mode_timeout**:
   - int, Set the length of time to wait for the host to move into the appropriate maintenance state before throwing an error.
@@ -50,9 +50,6 @@ pyvomi
   - str, Set the VSAN compliance mode for the host to enter.
   - One of `ensureObjectAccessibility`, `evacuateAllData`, `noAction`
 
-## Dependencies
-
-- NA
 
 ## Example Playbook
 ```yaml
@@ -88,7 +85,7 @@ License
 
 GNU General Public License v3.0 or later
 
-See [LICENCE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
+See [LICENSE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
 
 Author Information
 ------------------

--- a/roles/esxi_maintenance_mode/tasks/main.yml
+++ b/roles/esxi_maintenance_mode/tasks/main.yml
@@ -10,7 +10,7 @@
     quiet: true
     fail_msg: Variable must be set when using this role.
 
-- name: Set ESXI Maintenance Mode
+- name: Set ESXi Maintenance Mode
   community.vmware.vmware_maintenancemode:
     hostname: "{{ esxi_maintenance_mode_hostname }}"
     username: "{{ esxi_maintenance_mode_username }}"

--- a/roles/export_vm_as_ovf/README.md
+++ b/roles/export_vm_as_ovf/README.md
@@ -1,8 +1,8 @@
 # export_vm_as_ovf
 
-A role to export a VM from VCenter or ESXi as an OVF. The VM is exported to the local filesystem of the host running the tasks (anisble_host).
+A role to export a VM from vCenter or ESXi as an OVF. The VM is exported to the local filesystem of the host running the tasks (anisble_host).
 
-## Requirements
+## Dependencies
 
 N/A
 
@@ -34,7 +34,7 @@ N/A
   - str, The name of the datacenter that contains the VM that should be exported.
 
 - **export_vm_as_ovf_vm_folder**:
-  - str, The VCenter folder that contains the VM that should be exported. This should be the full folder path
+  - str, The vCenter folder that contains the VM that should be exported. This should be the full folder path
 
 - **export_vm_as_ovf_vm_moid**:
   - str, The MOID of the VM that should be exported.
@@ -70,10 +70,6 @@ N/A
   - str, The port of a proxy host that should be used for all HTTPs communication by the role. Optional
 
 
-## Dependencies
-
-- community.vmware
-
 ## Example Playbook
 ```yaml
 ---
@@ -95,7 +91,7 @@ N/A
 
 GNU General Public License v3.0 or later
 
-See [LICENCE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
+See [LICENSE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
 
 ## Author Information
 

--- a/roles/export_vm_as_ovf/README.md
+++ b/roles/export_vm_as_ovf/README.md
@@ -27,7 +27,7 @@ N/A
   - The name of the datacenter in vSphere vCenter which contains the VM.
 
 - **export_vm_as_ovf_port**:
-  - str or int, The port used to authenticate to the vSphere vCenter that contains the cluster to configure.
+  - str or int, The port used to authenticate to the vSphere vCenter that contains the VM.
 
 ### VM Options
 - **export_vm_as_ovf_vm_datacenter**:

--- a/roles/export_vm_as_ovf/README.md
+++ b/roles/export_vm_as_ovf/README.md
@@ -1,6 +1,6 @@
 # export_vm_as_ovf
 
-A role to export a VM from vCenter or ESXi as an OVF. The VM is exported to the local filesystem of the host running the tasks (anisble_host).
+A role to export a VM from vCenter or ESXi as an OVF. The VM is exported to the local filesystem of the host running the tasks (ansible_host).
 
 ## Dependencies
 
@@ -27,7 +27,7 @@ N/A
   - The name of the datacenter in vSphere vCenter which contains the VM.
 
 - **export_vm_as_ovf_port**:
-  - str or int, The port to use to authenticate to the vSphere vCenter which contains the VM.
+  - str or int, The port used to authenticate to the vSphere vCenter that contains the cluster to configure.
 
 ### VM Options
 - **export_vm_as_ovf_vm_datacenter**:
@@ -73,7 +73,7 @@ N/A
 ## Example Playbook
 ```yaml
 ---
-- name: Export VM To Lolcahost
+- name: Export VM To Localhost
   hosts: localhost
   gather_facts: false
 

--- a/roles/info/README.md
+++ b/roles/info/README.md
@@ -1,8 +1,8 @@
 # info
 
-A role that gather information from vCenter.
+A role that gathers information from vCenter.
 
-## Requirements
+## Dependencies
 
 N/A
 
@@ -150,11 +150,6 @@ An abbreviated example of the data returned can be found below:
   - File where to store the gathered data. Default is `/tmp/vmware_ops_info_guest`
   - If set to an empty string or `false`, the data is not written to a file.
 
-## Dependencies
-
-- community.vmware
-- vmware.vmware
-- vmware.vmware_rest
 
 ## Example Playbook
 ```yaml
@@ -185,7 +180,7 @@ An abbreviated example of the data returned can be found below:
 
 GNU General Public License v3.0 or later
 
-See [LICENCE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
+See [LICENSE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
 
 ## Author Information
 

--- a/roles/manage_folder/README.md
+++ b/roles/manage_folder/README.md
@@ -1,8 +1,8 @@
 # manage_folder
 
-A role to create, delete, or update a folder or folder tree in VCenter.
+A role to create, delete, or update a folder or folder tree in vCenter.
 
-## Requirements
+## Dependencies
 
 N/A
 
@@ -52,9 +52,6 @@ N/A
 - **manage_folder_proxy_port**:
   - str, The port of a proxy host that should be used for all HTTPs communication by the role. Optional
 
-## Dependencies
-
-- community.vmware
 
 ## Example Playbook
 ```yaml
@@ -121,7 +118,7 @@ N/A
 
 GNU General Public License v3.0 or later
 
-See [LICENCE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
+See [LICENSE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
 
 ## Author Information
 

--- a/roles/manage_folder/README.md
+++ b/roles/manage_folder/README.md
@@ -24,7 +24,7 @@ N/A
   - The name of the datacenter in vSphere vCenter which contains the cluster to configure.
 
 - **manage_folder_port**:
-  - str or int, The port to use to authenticate to the vSphere vCenter which contains the cluster to configure.
+  - str or int, The port used to authenticate to the vSphere vCenter that contains the cluster to configure.
 
 ### Other
 - **manage_folder_folder_name**:

--- a/roles/manage_folder/tasks/manage_path_part.yml
+++ b/roles/manage_folder/tasks/manage_path_part.yml
@@ -1,5 +1,5 @@
 ---
-- name: Manage VCenter Folder - {{ (_parent | ternary(_parent + '/', '')) + _child }}
+- name: Manage vCenter Folder - {{ (_parent | ternary(_parent + '/', '')) + _child }}
   community.vmware.vcenter_folder:
     hostname: "{{ manage_folder_hostname }}"
     username: "{{ manage_folder_username }}"

--- a/roles/provision_vcenter/README.md
+++ b/roles/provision_vcenter/README.md
@@ -2,27 +2,27 @@
 
 Provision a vCenter appliance on an ESXi host, using a vCenter ISO locally or VMX file on a datastore
 
-## Requirements
+## Dependencies
 
-pyvomi
+The vCenter Server Appliance ISO should be accessible from the host running these tasks, not necessarily the host onto which the appliance will be deployed. No customization of the ISO is required.
 
 ## Role Variables
 
 ### Auth
 - **provision_vcenter_hostname**:
-  - str, The hostname of the esxi or vcenter on which you want to deploy the application. Required.
+  - str, The hostname of the ESXi or vCenter on which you want to deploy the application. Required.
 
 - **provision_vcenter_username**:
-  - str, The username to use to authenticate to the esxi or vcenter on which you want to deploy the application. Required.
+  - str, The username to use to authenticate to the ESXi or vCenter on which you want to deploy the application. Required.
 
 - **provision_vcenter_password**:
-  - str, The password to use to authenticate to the esxi or vcenter on which you want to deploy the application. Required.
+  - str, The password to use to authenticate to the ESXi or vCenter on which you want to deploy the application. Required.
 
 - **provision_vcenter_port**:
-  - str or int, The port to use to authenticate to the esxi or vcenter on which you want to deploy the application. Required.
+  - str or int, The port to use to authenticate to the ESXi or vCenter on which you want to deploy the application. Required.
 
 - **provision_vcenter_validate_certs**:
-  - bool, If true then certificates will be validated when connecting to the esxi or vcenter for auth. Optional.
+  - bool, If true then certificates will be validated when connecting to the ESXi or vCenter for auth. Optional.
 
 ### Replication Options
 
@@ -36,7 +36,7 @@ pyvomi
 
 - **provision_vcenter_vc_target_esxi_path**:
   - str, The path/name of the ESXi server on which you want to deploy the appliance. Only required when VM does not exist and you are deploying into an existing vCenter server.
-  - This value should be the name (or path) found in vcenter, which is not necessarily the same as the hostname
+  - This value should be the name (or path) found in vCenter, which is not necessarily the same as the hostname
 
 ### Install Source
 - **provision_vcenter_iso_path**:
@@ -47,13 +47,13 @@ pyvomi
 
 ### VCSA VM
 - **provision_vcenter_vm_name**:
-  - str, The name for the vcenter vm, as seen in the web gui. Required.
+  - str, The name for the vCenter vm, as seen in the web GUI. Required.
 
 - **provision_vcenter_vm_uuid**:
   - str, Specify the full VM UUID if multiple VMs in your cluster have the same name as `provision_vcenter_vm_name`. Optional.
 
 - **provision_vcenter_vm_password**:
-  - str, Specify the password used to access this appliance once its deployed. Required if the VM does not already exist.
+  - str, Specify the password used to access this appliance once it's deployed. Required if the VM does not already exist.
   - This password is used for SSH access (username: root) if its enabled, as well as web GUI access (username: administrator@vsphere.local)
 
 - **provision_vcenter_vm_datastore**:
@@ -67,19 +67,19 @@ pyvomi
   - str, The network hostname (https://your_hostname) for vCenter. DNS should already resolve on the localhost. Required.
 
 - **provision_vcenter_vm_network_mode**:
-  - str, The type of network mode the vcenter vm should use. Can be 'static' or 'dhcp'. Default is 'static'.
+  - str, The type of network mode the vCenter vm should use. Can be 'static' or 'dhcp'. Default is 'static'.
 
 - **provision_vcenter_vm_network_address**:
-  - str, The private IP address the vcenter vm should use. Required if network mode is set to 'static'.
+  - str, The private IP address the vCenter vm should use. Required if network mode is set to 'static'.
 
 - **provision_vcenter_vm_network_prefix**:
-  - str or int, The digit netmask the vcenter vm should use. For example '24'.  Required if network mode is set to 'static'.
+  - str or int, The digit netmask the vCenter vm should use. For example '24'.  Required if network mode is set to 'static'.
 
 - **provision_vcenter_vm_network_gateway**:
-  - str or int, The gateway IP the vcenter vm should use. Required if network mode is set to 'static'.
+  - str or int, The gateway IP the vCenter vm should use. Required if network mode is set to 'static'.
 
 - **provision_vcenter_vm_network_dns**:
-  - list(str), A list of DNS servers the vcenter vm should use. Required if network mode is set to 'static'.
+  - list(str), A list of DNS servers the vCenter vm should use. Required if network mode is set to 'static'.
 
 - **provision_vcenter_vm_ntp_server**:
   - str or int, Server to use for NTP source.
@@ -88,17 +88,14 @@ pyvomi
   - str, The IP family that the VM should use for its network. ipv4 or ipv6. Default is ipv4
 
 - **provision_vcenter_vm_deployment_option**:
-  - str, The deployment "size" for the vcenter appliance. See the VMWare documentation for the accepted values and their requirements. Default is tiny.
+  - str, The deployment "size" for the vCenter appliance. See the VMWare documentation for the accepted values and their requirements. Default is tiny.
 
 - **provision_vcenter_vm_enable_ssh**:
-  - bool, Set to true to enable ssh on the vcenter appliance. Default is true.
+  - bool, Set to true to enable ssh on the vCenter appliance. Default is true.
 
 - **provision_vcenter_vm_enable_ceip**:
-  - bool, Set to true to opt into VMWares Customer Experience Improvement Program. Default is false.
+  - bool, Set to true to opt into VMwares Customer Experience Improvement Program. Default is false.
 
-## Dependencies
-
-- NA
 
 ## Example Playbook
 ```yaml
@@ -134,7 +131,7 @@ License
 
 GNU General Public License v3.0 or later
 
-See [LICENCE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
+See [LICENSE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
 
 Author Information
 ------------------

--- a/roles/provision_vcenter/README.md
+++ b/roles/provision_vcenter/README.md
@@ -88,7 +88,7 @@ The vCenter Server Appliance ISO should be accessible from the host running thes
   - str, The IP family that the VM should use for its network. ipv4 or ipv6. Default is ipv4
 
 - **provision_vcenter_vm_deployment_option**:
-  - str, The deployment "size" for the vCenter appliance. See the VMWare documentation for the accepted values and their requirements. Default is tiny.
+  - str, The deployment "size" for the vCenter appliance. See the VMware documentation for the accepted values and their requirements. Default is tiny.
 
 - **provision_vcenter_vm_enable_ssh**:
   - bool, Set to true to enable ssh on the vCenter appliance. Default is true.

--- a/roles/provision_vcenter/tasks/main.yml
+++ b/roles/provision_vcenter/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Validate Inputs
   ansible.builtin.include_tasks: validate_inputs.yml
 
-- name: Check If VCenter Already Exists
+- name: Check If vCenter Already Exists
   vmware.vmware.guest_info:
     hostname: "{{ provision_vcenter_hostname }}"
     username: "{{ provision_vcenter_username }}"
@@ -36,7 +36,7 @@
           paths:
             - os_specific_iso_actions
 
-- name: Make Sure VCenter Appliance Is Powered On
+- name: Make Sure vCenter Appliance Is Powered On
   community.vmware.vmware_guest_powerstate:
     hostname: "{{ provision_vcenter_hostname }}"
     username: "{{ provision_vcenter_username }}"

--- a/roles/provision_vcenter/tasks/validate_inputs.yml
+++ b/roles/provision_vcenter/tasks/validate_inputs.yml
@@ -37,7 +37,7 @@
       - provision_vcenter_vm_network_gateway is defined
       - provision_vcenter_vm_network_dns is defined
     quiet: true
-    fail_msg: Variable must be set when deploying vcenter with a static IP.
+    fail_msg: Variable must be set when deploying vCenter with a static IP.
   when: provision_vcenter_vm_network_mode == "static"
 
 - name: Check ISO Is Accessible By Ansible Host

--- a/roles/provision_vcenter/templates/README.md
+++ b/roles/provision_vcenter/templates/README.md
@@ -39,7 +39,7 @@ You can list these sizes by running the command: `./vcsa-cli-installer/lin64/vcs
 
 ## Additional VMware Documentation
 
-VMWare publishes ISO cli information online. It is dependent on the vSphere version, so refering to the commands provided by the ISO may be preferred. <br>
+VMWare publishes ISO cli information online. It is dependent on the vSphere version, so referring to the commands provided by the ISO may be preferred. <br>
 Below are some helpful document names and links to versions of that documentation.
 
 [Prepare Your JSON Configuration File for CLI Deployment](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vcenter.install.doc/GUID-3683BA76-B08A-4DDB-9CCF-66660F6AD1CF.html)<br>

--- a/roles/provision_virtual_esxi/README.md
+++ b/roles/provision_virtual_esxi/README.md
@@ -2,27 +2,30 @@
 
 Provision one or more virtual ESXi hosts
 
-## Requirements
+## Dependencies
 
-pyvomi
+When deploying a new VM:
+  You should have an ESXi ISO that the VM can access in order to boot and install the ESXi OS. A common storage place would be a datastore that is accessible to the host running the new VM. The ISO should be pre-configured for an unattended install, or you should be prepared to manually complete the install process via console. The role will know when the install is complete when the new VM is powered off or has an IP address.
+
+  This role will import the cloud.vmware_ops.provision_vm role automatically.
 
 ## Role Variables
 
 ### Auth
 - **provision_virtual_esxi_hostname**:
-  - str, The name of the esxi or vcenter on which you want to deploy the vm. Required.
+  - str, The name of the ESXi or vCenter on which you want to deploy the vm. Required.
 
 - **provision_virtual_esxi_username**:
-  - str, The username to use to authenticate to the esxi or vcenter on which you want to deploy the vm. Required.
+  - str, The username to use to authenticate to the ESXi or vCenter on which you want to deploy the vm. Required.
 
 - **provision_virtual_esxi_password**:
-  - str, The password to use to authenticate to the esxi or vcenter on which you want to deploy the vm. Required.
+  - str, The password to use to authenticate to the ESXi or vCenter on which you want to deploy the vm. Required.
 
 - **provision_virtual_esxi_validate_certs**:
-  - bool, If true then certificates will be validated when connecting to the esxi or vcenter for auth. Optional.
+  - bool, If true then certificates will be validated when connecting to the ESXi or vCenter for auth. Optional.
 
 - **provision_virtual_esxi_port**:
-  - int, The port to use when connecting to the esxi or vcenter for auth. Optional.
+  - int, The port to use when connecting to the ESXi or vCenter for auth. Optional.
 
 ### Placement
 - **provision_virtual_esxi_cluster**:
@@ -32,7 +35,7 @@ pyvomi
   - str, The name of the datacenter in which you want to deploy the new vms.
 
 - **provision_virtual_esxi_resource_pool**:
-  - str, The name of the resource pool in which to place the VMs. Its recommended to use a resource pool and limit the amount of resources these ESXi hosts can use
+  - str, The name of the resource pool in which to place the VMs. It's recommended to use a resource pool and limit the amount of resources these ESXi hosts can use
 
 - **provision_virtual_esxi_folder**:
   - str, The name of the folder in which to place the VMs
@@ -40,7 +43,7 @@ pyvomi
 
 ### VM Options
 - **provision_virtual_esxi_vms**:
-  - list(dict), A list of dictionaries describing the esxi hosts you want to manage. If no VM exists with the name, a new VM will be created. VMs are created in booted to save time.
+  - list(dict), A list of dictionaries describing the ESXi hosts you want to manage. If no VM exists with the name, a new VM will be created. VMs are created in parallel to save time.
   - **Members**
     - name - str, The name of the VM that you want to manage. Required
     - networks - list(dict), The network definition specific to this VM. If undefined, the value from `provision_virtual_esxi_networks` is used.
@@ -71,10 +74,6 @@ pyvomi
   - str, The type of boot firmware that the VM should be configured to use. 'bios' or 'uefi'
   - Default value is 'bios'
 
-
-## Dependencies
-
-- NA
 
 ## Example Playbook
 ```yaml
@@ -113,7 +112,7 @@ License
 
 GNU General Public License v3.0 or later
 
-See [LICENCE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
+See [LICENSE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
 
 Author Information
 ------------------

--- a/roles/provision_virtual_esxi/defaults/main.yml
+++ b/roles/provision_virtual_esxi/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-# hardware defaults are chosen based on the minimum requirements to run vcenter,
-# plus a little bit extra for the ESXI system
+# hardware defaults are chosen based on the minimum requirements to run vCenter,
+# plus a little bit extra for the ESXi system
 # https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-vcenter-upgrade/GUID-752FCA83-1A9B-499E-9C65-D5625351C0B5.html
 provision_virtual_esxi_memory_mb: 18000
 provision_virtual_esxi_cpus: 4

--- a/roles/provision_vm/README.md
+++ b/roles/provision_vm/README.md
@@ -1,9 +1,10 @@
 # provision_vm
-A role to provision a virtual machine, create associated resources if they don't exist (subnets, vCPU, memory configuration, storage configuration, etc)
+A role to provision a virtual machine and create associated resources if they don't exist (subnets, vCPU, memory configuration, storage configuration, etc).
 This includes cloning and building from VM templates.
 
 
-## Requirements
+## Dependencies
+
 N/A
 
 
@@ -20,6 +21,7 @@ N/A
 
 - **provision_vm_validate_certs** (boolean)
   - Allows connection when SSL certificates are not valid. Set to false when certificates are not trusted.
+    Default: true
 
 - **provision_vm_port** (integer):
     The port number of the vSphere vCenter or ESXi server.
@@ -37,729 +39,697 @@ N/A
 
 ### Provisioning a VM
 - **provision_vm_name**  (string, Required):
-    Name of the virtual machine to work with.
-    Virtual machine names in vCenter are not necessarily unique, which may be problematic, see O(name_match).
-    If multiple virtual machines with same name exists, then O(folder) is required parameter to
-    identify uniqueness of the virtual machine.
-    This parameter is required, if (state=poweredon), (state=powered-on), (state=poweredoff), (state=powered-off),
-    (state=present), (state=restarted), (state=suspended) and virtual machine does not exists.
-    This parameter is case sensitive.
+    - Name of the virtual machine to manage.
+    - Virtual machine names in vCenter are not necessarily unique which may be problematic.
+      If multiple virtual machines with same name exists, then `provision_vm_folder` is required parameter to
+      identify uniqueness of the virtual machine. You can also set `provision_vm_name_match` to control how multiple matching VM names are handled.
+    - The parameter is required if the virtual machine does not already exist.
+    - This parameter is case sensitive.
 
 - **provision_vm_uuid**  (string):
-    UUID of the virtual machine to manage if known, this is VMware's unique identifier.
-    This is required if O(name) is not supplied.
-    If virtual machine does not exists, then this parameter is ignored.
-    Please note that a supplied UUID will be ignored on virtual machine creation, as VMware creates the UUID internally.
+    - The instance UUID of the virtual machine to manage.
+    - This is required if `provision_vm_name` is not supplied.
+    - Note that a supplied UUID will be ignored on virtual machine creation, as VMware creates the UUID internally.
+      If virtual machine does not exists, then this parameter is ignored.
 
 - **provision_vm_cluster** (String):
-    The cluster name where the virtual machine will run.
+    - The name of the cluster where the virtual machine will run.
 
 - **provision_vm_esxi_hostname** (string):
-    The ESXi hostname where the virtual machine will run.
-    This is a required parameter, if cluster is not set.
-    esxi_hostname and cluster are mutually exclusive parameters.
-    This parameter is case sensitive.
+    - The ESXi hostname where the virtual machine will run. This is a required parameter if `provision_vm_cluster` is not set.
+    - `provision_vm_esxi_hostname` and `provision_vm_cluster` are mutually exclusive parameters.
+    - This parameter is case sensitive.
 
 - **provision_vm_datacenter** (string):
-    Destination datacenter for the deploy operation.
-    This parameter is case sensitive.
-    Default: "ha-datacenter"
+    - The name of the datacenter where the virtual machine will run.
+    - This parameter is case sensitive.
+    - Default: "ha-datacenter"
 
 - **provision_vm_folder** (string):
-    Destination folder, absolute path to find an existing guest or create the new guest.
-    The folder should include the datacenter. ESXi's datacenter is ha-datacenter.
-    This parameter is case sensitive.
-    If multiple machines are found with same name, this parameter is used to identify
-    uniqueness of the virtual machine.
+    - Absolute path to the folder where the VM will exist.
+    - The folder should include the datacenter. A single ESXi's datacenter is `ha-datacenter`.
+    - This parameter is case sensitive.
+    - If multiple machines are found with same name, this parameter is used to identify uniqueness of the virtual machine.
 
 - **provision_vm_datastore** (string):
-    Specify datastore or datastore cluster to provision virtual machine.
-    This parameter takes precedence over disk.datastore parameter.
-    This parameter can be used to override datastore or datastore cluster setting of the virtual machine when deployed from the template.
-    Please see example for more usage.
+    - Specify datastore or datastore cluster to use for the virtual machine backend storage.
+    - This parameter takes precedence over the `provision_vm_disk.datastore` parameter.
+    - This parameter can be used to override datastore or datastore cluster setting of the virtual machine when deploying from a template.
+    - Please see the examples for more usage.
 
 - **provision_vm_resource_pool** (string):
-    Use the given resource pool for virtual machine operation.
-    This parameter is case sensitive.
-    Resource pool should be child of the selected host parent.
-    When not specified Resources is taken as default value.
+    - The name of a resource pool in which the VM should exist.
+    - This parameter is case sensitive.
+    - The resource pool should be child of the selected ESXi host or cluster.
 
 - **provision_vm_template** (string):
-    Template or existing virtual machine used to create new virtual machine.
-    If this value is not set, virtual machine is created without using a template.
-    If the virtual machine already exists, this parameter will be ignored.
-    This parameter is case sensitive.
-    From version 2.8 onwards, absolute path to virtual machine or template can be used.
+    - A template or existing virtual machine that should be used to create the new virtual machine.
+    - If this value is not set, the virtual machine is created without using a template.
+    - If the virtual machine already exists, this parameter will be ignored.
+    - This parameter is case sensitive.
+    - This can be the name of the template or the absolute folder path to the template
 
 - **provision_vm_convert** (string):
-    Specify convert disk type while cloning template or virtual machine.
-    Choices:
-    - "thin"
-    - "thick"
-    - "eagerzeroedthick"
+    - Specify if the disk should be converted to a new type while cloning an existing template or virtual machine.
+    - Choices:
+        - "thin"
+        - "thick"
+        - "eagerzeroedthick"
 
 - **provision_vm_linked_clone** (boolean):
-    Whether to create a linked clone from the snapshot specified.
-    If specified, then snapshot_src is required parameter.
-    Choices:
-    - false ← (default)
-    - true
+    - Specify if the clone should be linked to the snapshot from which it was created.
+    - If specified, then `provision_vm_snapshot_src` is required.
+    - Choices:
+        - false (default)
+        - true
 
 - **provision_vm_snapshot_src** (string):
-    Name of the existing snapshot to use to create a clone of a virtual machine.
-    This parameter is case sensitive.
-    While creating linked clone using linked_clone parameter, this parameter is required.
+    - Name of the existing snapshot to clone and use to create a new virtual machine.
+    - This parameter is case sensitive.
+    - This parameter is required when using the `provision_vm_linked_clone` parameter.
 
 - **provision_vm_advanced_settings** (list):
-    Define a list of advanced settings to be added to the VMX config.
-    An advanced settings object takes the two fields key and value.
+    - Define a list of advanced settings to be added to the VMX config.
+    - Each element in the advanced settings list should include `key` and `value` attributes.
+    - Example: `[{key: foo, value: bar}]`
 
 - **provision_vm_annotation** (string):
-    A note or annotation to include in the virtual machine.
+    - A note or annotation to include in the virtual machine metadata.
 
 - **provision_vm_cdrom** (list):
-    A list of CD-ROM configurations for the virtual machine.
-    For ide controller, hot-add or hot-remove CD-ROM is not supported.
-
-    Element keys:
-     * type:
-        type: str
-        description:
-        - The type of CD-ROM.
-        - With V(none) the CD-ROM will be disconnected but present.
-        choices: [ 'none', 'client', 'iso' ]
-        default: client
+    - A list of CD-ROM configurations for the virtual machine.
+    - For ide controllers, hot-adding or hot-removing CD-ROMs is not supported.
+    - Each element in the list is a dictionary, described below.
+    * type:
+        - type: str
+        - description:
+            - The type of CD-ROM.
+            - When `none` the CD-ROM will be disconnected but present.
+        - choices: [ 'none', 'client', 'iso' ]
+        - default: client
     * iso_path:
-        type: str
-        description:
-        - The datastore path to the ISO file to use, in the form of C([datastore1] path/to/file.iso).
-        - Required if type is set V(iso).
+        - type: str
+        - description:
+            - The datastore path to the ISO file to use, in the form of `[datastore1] path/to/file.iso`.
+            - Required if type is set `iso`.
     * controller_type:
-        type: str
-        description:
-        - When set to V(sata), please make sure O(cdrom.unit_number) is correct and not used by SATA disks.
-        choices: [ 'ide', 'sata' ]
-        default: ide
+        - type: str
+        - description:
+            - When set to `sata`, please make sure `unit_number` is correct and not used by SATA disks.
+        - choices: [ 'ide', 'sata' ]
+        - default: ide
     * controller_number:
-        type: int
-        description:
-        - For O(cdrom.controller_type=ide), valid value is 0 or 1.
-        - For O(cdrom.controller_type=sata), valid value is 0 to 3.
+        - type: int
+        - description:
+            - If `controller_type` is `ide`, valid value is 0 or 1.
+            - If `controller_type` is `sata`, valid value is 0 to 3.
     * unit_number:
-        type: int
-        description:
-        - For O(cdrom.controller_type=ide), valid value is 0 or 1.
-        - For O(cdrom.controller_type=sata), valid value is 0 to 29.
-        - O(cdrom.controller_number) and O(cdrom.unit_number) are mandatory attributes.
+        - type: int
+        - description:
+            - If `controller_type` is `ide`, valid value is 0 or 1.
+            - If `controller_type` is `sata`, valid value is 0 to 29.
+            - `controller_number` and `unit_number` are mandatory attributes.
     * state:
-        type: str
-        description:
-        - If set to V(absent), then the specified CD-ROM will be removed.
-        choices: [ 'present', 'absent' ]
-        default: present
+        - type: str
+        - description:
+            - If set to `absent`, then the specified CD-ROM will be removed.
+        - choices: [ 'present', 'absent' ]
+        - default: present
 
 - **provision_vm_customization** (dictionary):
-    Parameters for OS customization when cloning from the template or the virtual machine, or apply to the existing virtual machine directly.
-    Not all operating systems are supported for customization with respective vCenter version, please check VMware documentation for respective OS customization.
-    For supported customization operating system matrix, (see http://partnerweb.vmware.com/programs/guestOS/guest-os-customization-matrix.pdf)
-    All parameters and VMware object names are case sensitive.
-    Linux based OSes requires Perl package to be installed for OS customizations.
-
-    Element keys:
+    - Set parameters for OS customization when cloning from a template or a virtual machine, or apply customization to an existing virtual machine. Customization will be applied when the VM is powered on next.
+    - Not all operating systems are supported for customization depending on the vCenter version, please check VMware documentation.
+    - For the supported customization operating system matrix, see http://partnerweb.vmware.com/programs/guestOS/guest-os-customization-matrix.pdf
+    - All parameters and VMware object names are case sensitive.
+    - Linux OSes require the perl package to be installed for the `script_text` OS customization.
+    - Dictionary elements are described below
     * existing_vm:
-        type: bool
-        description:
-        - If set to V(true), do OS customization on the specified virtual machine directly.
-        - Common for Linux and Windows customization.
+        - type: bool
+        - description:
+            - If set to `true`, apply OS customization directly to the specified virtual machine.
     * dns_servers:
-        type: list
-        elements: str
-        description:
-        - List of DNS servers to configure.
-        - Common for Linux and Windows customization.
+        - type: list
+        - elements: str
+        - description:
+            - List of DNS servers to configure.
     * dns_suffix:
-        type: list
-        elements: str
-        description:
-        - List of domain suffixes, also known as DNS search path.
-        - Default C(domain) parameter.
-        - Common for Linux and Windows customization.
+        - type: list
+        - elements: str
+        - description:
+            - List of domain suffixes, also known as DNS search path.
+            - Default value is the `domain`
     * domain:
-        type: str
-        description:
-        - DNS domain name to use.
-        - Common for Linux and Windows customization.
+        - type: str
+        - description:
+            - DNS domain name to use.
     * hostname:
-        type: str
-        description:
-        - Computer hostname.
-        - Default is shortened O(name) parameter.
-        - Allowed characters are alphanumeric (uppercase and lowercase) and minus, rest of the characters are dropped as per RFC 952.
-        - Common for Linux and Windows customization.
+        - type: str
+        - description:
+            - Computer hostname.
+            - Default is shortened `provision_vm_name` parameter.
+            - Allowed characters are alphanumeric (uppercase and lowercase) and minus, rest of the characters are dropped as per RFC 952.
     * timezone:
-        type: str
-        description:
-        - Timezone.
-        - See List of supported time zones for different vSphere versions in Linux/Unix.
-        - Common for Linux and Windows customization.
-        - L(Windows, https://msdn.microsoft.com/en-us/library/ms912391.aspx).
+        - type: str
+        - description:
+            - Timezone.
+            - See List of supported time zones for different vSphere versions in Linux/Unix.
+            - For Windows, see https://msdn.microsoft.com/en-us/library/ms912391.aspx
     * hwclockUTC:
-        type: bool
-        description:
-        - Specifies whether the hardware clock is in UTC or local time.
-        - Specific to Linux customization.
+        - type: bool
+        - description:
+            - Specifies whether the hardware clock is in UTC or local time.
+            - Specific to Linux customization.
     * script_text:
-        type: str
-        description:
-        - Script to run with shebang.
-        - Needs to be enabled in vmware tools with vmware-toolbox-cmd config set deployPkg enable-custom-scripts true
-        - https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-9A5093A5-C54F-4502-941B-3F9C0F573A39.html
-        - Specific to Linux customization.
-        version_added: '3.1.0'
+        - type: str
+        - description:
+            - Script to run with shebang.
+            - Needs to be enabled in vmware tools with `vmware-toolbox-cmd config set deployPkg enable-custom-scripts true`
+            - https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-9A5093A5-C54F-4502-941B-3F9C0F573A39.html
+            - Specific to Linux customization.
+        - version_added: '3.1.0'
     * autologon:
-        type: bool
-        description:
-        - Auto logon after virtual machine customization.
-        - Specific to Windows customization.
+        - type: bool
+        - description:
+            - Auto logon after virtual machine customization.
+            - Specific to Windows customization.
     * autologoncount:
-        type: int
-        description:
-        - Number of autologon after reboot.
-        - Specific to Windows customization.
-        - Ignored if O(customization.autologon) is unset or set to O(customization.autologon=false).
-        - If unset, 1 will be used.
+        - type: int
+        - description:
+            - Number of autologon after reboot.
+            - Specific to Windows customization.
+            - Ignored if `autologon` is unset or set to `false`.
+            - If unset, 1 will be used.
     * domainadmin:
-        type: str
-        description:
-        - User used to join in AD domain.
-        - Required if O(customization.joindomain) specified.
-        - Specific to Windows customization.
+        - type: str
+        - description:
+            - User used to join the AD domain.
+            - Required if `joindomain` is specified.
+            - Specific to Windows customization.
     * domainadminpassword:
-        type: str
-        description:
-        - Password used to join in AD domain.
-        - Required if O(customization.joindomain) specified.
-        - Specific to Windows customization.
+        - type: str
+        - description:
+            - Password used to join the AD domain.
+            - Required if `joindomain` is specified.
+            - Specific to Windows customization.
     * fullname:
-        type: str
-        description:
-        - Server owner name.
-        - Specific to Windows customization.
-        - If unset, "Administrator" will be used as a fall-back.
+        - type: str
+        - description:
+            - Server owner name.
+            - Specific to Windows customization.
+            - Default is "Administrator"
     * joindomain:
-        type: str
-        description:
-        - AD domain to join.
-        - Not compatible with O(customization.joinworkgroup).
-        - Specific to Windows customization.
+        - type: str
+        - description:
+            - AD domain to join.
+            - Not compatible with `joinworkgroup`.
+            - Specific to Windows customization.
     * joinworkgroup:
-        type: str
-        description:
-        - Workgroup to join.
-        - Not compatible with O(customization.joindomain).
-        - Specific to Windows customization.
-        - If unset, "WORKGROUP" will be used as a fall-back.
+        - type: str
+        - description:
+            - Workgroup to join.
+            - Not compatible with `joindomain`.
+            - Specific to Windows customization.
+            - Default is "WORKGROUP"
     * orgname:
-        type: str
-        description:
-        - Organisation name.
-        - Specific to Windows customization.
-        - If unset, "ACME" will be used as a fall-back.
+        - type: str
+        - description:
+            - Organization name.
+            - Specific to Windows customization.
+            - Default is "ACME"
     * password:
-        type: str
-        description:
-        - Local administrator password.
-        - If not defined, the password will be set to blank (that is, no password).
-        - Specific to Windows customization.
+        - type: str
+        - description:
+            - Local administrator password.
+            - If not defined, the password will be set to blank (that is, no password).
+            - Specific to Windows customization.
     * productid:
-        type: str
-        description:
-        - Product ID.
-        - Specific to Windows customization.
+        - type: str
+        - description:
+            - Product ID.
+            - Specific to Windows customization.
     * runonce:
-        type: list
-        elements: str
-        description:
-        - List of commands to run at first user logon.
-        - Specific to Windows customization.
-
+        - type: list
+        - elements: str
+        - description:
+            - List of commands to run at first user logon.
+            - Specific to Windows customization.
 
 - **provision_vm_customization_spec** (string):
-    Unique name identifying the requested customization specification.
-    This parameter is case sensitive.
-    If set, then overrides customization parameter values.
+    - Unique name identifying the requested customization specification.
+    - This parameter is case sensitive.
+    - If set, this overrides customization parameter values.
 
 - **provision_vm_customvalues** (list)
-    Define a list of custom values to set on virtual machine.
-    A custom value object takes the two fields key and value.
-    Incorrect key and values will be ignored.
+    - Define a list of custom values to set on virtual machine.
+    - Each element in the list should have a `key` and `value` attribute.
+    - Incorrect key and values will be ignored.
+    - Example `[{key: foo, value: bar}]`
 
 - **provision_vm_delete_from_inventory** (boolean):
-    Whether to delete Virtual machine from inventory or delete from disk.
-    Choices:
-    - false ← (default)
-    - true
+    - If true the virtual machine's disks will not be deleted when `provision_vm_state` is `absent`, but the VM will still be removed from the vSphere inventory.
+    - Choices:
+        - false (default)
+        - true
 
 - **provision_vm_disk** (list):
-    A list of disks to add.
-    This parameter is case sensitive.
-    Shrinking disks is not supported.
-    Removing existing disks of the virtual machine is not supported.
-    Attributes disk.controller_type, disk.controller_number, disk.unit_number are used to configure multiple types of disk controllers and disks for creating or reconfiguring virtual machine.
-
-    Element keys:
+    - A list of disks to add.
+    - This parameter is case sensitive.
+    - Shrinking disks is not supported.
+    - Removing existing disks of the virtual machine is not supported.
+    - Attributes `controller_type`, `controller_number`, and `unit_number` are used to configure multiple types of disk controllers and disks for creating or reconfiguring virtual machine.
+    - Each item in the list may have the following attributes:
     * size:
-        description:
-        - Disk storage size.
-        - Please specify storage unit like [kb, mb, gb, tb].
-        type: str
+        - description:
+            - Disk storage size.
+            - You should include the storage unit like 100kb, 100mb, etc
+        - type: str
     * size_kb:
-        description: Disk storage size in kb.
-        type: int
+        - description: Disk storage size in kb.
+        - type: int
     * size_mb:
-        description: Disk storage size in mb.
-        type: int
+        - description: Disk storage size in mb.
+        - type: int
     * size_gb:
-        description: Disk storage size in gb.
-        type: int
+        - description: Disk storage size in gb.
+        - type: int
     * size_tb:
-        description: Disk storage size in tb.
-        type: int
+        - description: Disk storage size in tb.
+        - type: int
     * type:
-        description:
-        - Type of disk.
-        - If not specified, disk type is inherited from the source VM or template when cloned and thick disk, no eagerzero otherwise.
-        type: str
-        choices: [ 'thin', 'thick', 'eagerzeroedthick' ]
+        - description:
+            - Type of disk.
+            - If not specified, disk type is inherited from the source VM or template when cloned and thick disk, no eagerzero otherwise.
+        - type: str
+        - choices: [ 'thin', 'thick', 'eagerzeroedthick' ]
     * datastore:
-        type: str
-        description:
-        - The name of datastore which will be used for the disk.
-        - If O(disk.autoselect_datastore) is set to True, will select the less used datastore whose name contains this "disk.datastore" string.
+        - type: str
+        - description:
+            - The name of datastore which will be used for the disk.
+            - If `autoselect_datastore` is set to True, will select the less used datastore whose name contains this `datastore` string.
     * filename:
-        type: str
-        description:
-        - Existing disk image to be used.
-        - Filename must already exist on the datastore.
-        - Specify filename string in C([datastore_name] path/to/file.vmdk) format.
+        - type: str
+        - description:
+            - Existing disk image to be used.
+            - Filename must already exist on the datastore.
+            - Specify filename string in `[datastore_name] path/to/file.vmdk` format.
     * autoselect_datastore:
-        type: bool
-        description:
-        - Select the less used datastore.
-        - O(disk.datastore) and O(disk.autoselect_datastore) will not be used if O(datastore) is specified outside this O(disk) configuration.
+        - type: bool
+        - description:
+            - Select the less used datastore.
+            - `datastore` and `autoselect_datastore` will not be used if `provision_vm_datastore` is specified.
     * disk_mode:
-        type: str
-        choices: ['persistent', 'independent_persistent', 'independent_nonpersistent']
-        description:
-        - Type of disk mode.
-        - If V(persistent) specified, changes are immediately and permanently written to the virtual disk. This is default.
-        - If V(independent_persistent) specified, same as persistent, but not affected by snapshots.
-        - If V(independent_nonpersistent) specified, changes to virtual disk are made to a redo log and discarded at power off,
-          but not affected by snapshots.
+        - type: str
+        - choices: ['persistent', 'independent_persistent', 'independent_nonpersistent']
+        - description:
+            - Type of disk mode.
+            - If `persistent` specified, changes are immediately and permanently written to the virtual disk. This is default.
+            - If `independent_persistent` specified, same as persistent, but not affected by snapshots.
+            - If `independent_nonpersistent` specified, changes to virtual disk are made to a redo log and discarded at power off, but not affected by snapshots.
     * controller_type:
-        type: str
-        choices: ['buslogic', 'lsilogic', 'lsilogicsas', 'paravirtual', 'sata', 'nvme']
-        description:
-        - Type of disk controller.
-          Set this type on not supported ESXi or VM hardware version will lead to failure in deployment.
-        - When set to V(sata), please make sure O(disk.unit_number) is correct and not used by SATA CDROMs.
-        - If set to V(sata) type, please make sure O(disk.controller_number) and O(disk.unit_number) are set correctly when O(cdrom=sata).
+        - type: str
+        - choices: ['buslogic', 'lsilogic', 'lsilogicsas', 'paravirtual', 'sata', 'nvme']
+        - description:
+            - Type of disk controller.
+            - Set this type on not supported ESXi or VM hardware version will lead to failure in deployment.
+            - If set to `sata` type, please make sure `controller_number` and `unit_number` do not conflict with sata values in `provison_vm_cdrom`.
     * controller_number:
-        type: int
-        choices: [0, 1, 2, 3]
-        description:
-        - Disk controller bus number.
-        - The maximum number of same type controller is 4 per VM.
+        - type: int
+        - choices: [0, 1, 2, 3]
+        - description:
+            - Disk controller bus number.
+            - The maximum number of same type controller is 4 per VM.
     * unit_number:
-        type: int
-        description:
-        - Disk Unit Number.
-        - Valid value range from 0 to 15 for SCSI controller, except 7.
-        - Valid value range from 0 to 14 for NVME controller.
-        - Valid value range from 0 to 29 for SATA controller.
-        - O(disk.controller_type), O(disk.controller_number) and O(disk.unit_number) are required when creating or reconfiguring VMs
-          with multiple types of disk controllers and disks.
-        - When creating new VM, the first configured disk in the O(disk) list will be "Hard Disk 1".
+        - type: int
+        - description:
+            - Disk Unit Number.
+            - Valid value range from 0 to 15 for SCSI controller, except 7.
+            - Valid value range from 0 to 14 for NVME controller.
+            - Valid value range from 0 to 29 for SATA controller.
+            - `controller_type`, `controller_number` and `unit_number` are required when creating or reconfiguring VMs with multiple types of disk controllers and disks.
+            - When creating new VM, the first configured disk in the `provision_vm_disk` list will be "Hard Disk 1".
 
 - **provision_vm_encryption** (dictionary):
-    Manage virtual machine encryption settings
-    All parameters case sensitive.
-    Element keys:
+    - Manage virtual machine encryption settings
+    - All parameters case sensitive.
+    - The dictionary may have the following attributes:
     * encrypted_vmotion:
-        type: str
-        description: Controls encryption for live migrations with vmotion
-        choices: ['disabled', 'opportunistic', 'required']
+        - type: str
+        - description: Controls encryption for live migrations with vmotion
+        - choices: ['disabled', 'opportunistic', 'required']
     * encrypted_ft:
-        type: str
-        description: Controls encryption for fault tolerance replication
-        choices: ['disabled', 'opportunistic', 'required']
+        - type: str
+        - description: Controls encryption for fault tolerance replication
+        - choices: ['disabled', 'opportunistic', 'required']
 
 - **provision_vm_force** (boolean):
-    Ignore warnings and complete the actions.
-    This parameter is useful while removing virtual machine which is powered on state.
-    This module reflects the VMware vCenter API and UI workflow, as such, in some cases the `force` flag will be mandatory to perform the action to ensure you are certain the action has to be taken, no matter what the consequence. This is specifically the case for removing a powered on the virtual machine when state=absent.
-    Choices:
-    - false ← (default)
-    - true
+    - Ignore warnings and complete the actions.
+    - This parameter is useful while removing virtual machine which is powered on state.
+    - Choices:
+        - false
+        - true
 
 - **provision_vm_guest_id** (string):
-    Set the guest ID.
-    This parameter is case sensitive.
-    This field is required when creating a virtual machine, not required when creating from the template.
-    Valid values are referenced [here](https://vdc-download.vmware.com/vmwb-repository/dcr-public/184bb3ba-6fa8-4574-a767-d0c96e2a38f4/ba9422ef-405c-47dd-8553-e11b619185b2/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html).
+    - Set the guest ID.
+    - This parameter is case sensitive.
+    - This field is required when creating a new virtual machine and not required when creating from the template.
+    - Valid values are referenced [here](https://vdc-download.vmware.com/vmwb-repository/dcr-public/184bb3ba-6fa8-4574-a767-d0c96e2a38f4/ba9422ef-405c-47dd-8553-e11b619185b2/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html).
 
 - **provision_vm_hardware** (dictionary):
-    Manage virtual machine's hardware attributes.
-    All parameters case sensitive.
-    Keys:
+    - Manage virtual machine's hardware attributes.
+    - All parameters case sensitive.
+    - The dictionary may have the following attributes:
     * hotadd_cpu:
-        type: bool
-        description: Allow virtual CPUs to be added while the virtual machine is running.
+        - type: bool
+        - description:
+            - Allow virtual CPUs to be added while the virtual machine is running.
+            - Must be set when the VM is first created and is powered off.
     * hotremove_cpu:
-        type: bool
-        description: Allow virtual CPUs to be removed while the virtual machine is running.
+        - type: bool
+        - description:
+            - Allow virtual CPUs to be removed while the virtual machine is running.
+            - Must be set when the VM is first created and is powered off.
     * hotadd_memory:
-        type: bool
-        description: Allow memory to be added while the virtual machine is running.
+        - type: bool
+        - description:
+            - Allow memory to be added while the virtual machine is running.
+            - Must be set when the VM is first created and is powered off.
     * memory_mb:
-        type: int
-        description: Amount of memory in MB.
+        - type: int
+        - description: Amount of memory in MB.
     * num_cpus:
-        type: int
-        description:
-        - Number of CPUs.
-        - Must be a multiple of O(hardware.num_cpu_cores_per_socket).
-        - For example, to create a VM with 2 sockets of 4 cores, specify O(hardware.num_cpus) as 8 and O(hardware.num_cpu_cores_per_socket) as 4.
+        - type: int
+        - description:
+            - Number of CPUs.
+            - Must be a multiple of `num_cpu_cores_per_socket`
+            - For example, to create a VM with 2 sockets of 4 cores, specify `num_cpus` as 8 and `num_cpu_cores_per_socket` as 4.
     * num_cpu_cores_per_socket:
-        type: int
-        description: Number of Cores Per Socket.
+        - type: int
+        - description: Number of Cores Per Socket.
     * cpu_shares_level:
-        type: str
-        choices: [ 'low', 'normal', 'high', 'custom' ]
-        description:
-        - The allocation level of CPU resources for the virtual machine.
-        version_added: '3.2.0'
+        - type: str
+        - choices: [ 'low', 'normal', 'high', 'custom' ]
+        - description:
+            - The allocation level of CPU resources for the virtual machine.
+        - version_added: '3.2.0'
     * cpu_shares:
-        type: int
-        description:
-        - The number of shares of CPU allocated to this virtual machine
-        - cpu_shares_level will automatically be set to 'custom'
-        version_added: '3.2.0'
+        - type: int
+        - description:
+            - The number of shares of CPU allocated to this virtual machine
+            - cpu_shares_level will automatically be set to 'custom'
+        - version_added: '3.2.0'
     * vpmc_enabled:
-        version_added: '3.2.0'
-        type: bool
-        description: Enable virtual CPU Performance Counters.
+        - version_added: '3.2.0'
+        - type: bool
+        - description: Enable virtual CPU Performance Counters.
     * scsi:
-        type: str
-        description:
-        - Valid values are V(buslogic), V(lsilogic), V(lsilogicsas) and V(paravirtual).
-        - V(paravirtual) is default.
+        - type: str
+        - description:
+            - The type of scsi device to use.
+            - Default is paravirtual
         choices: [ 'buslogic', 'lsilogic', 'lsilogicsas', 'paravirtual' ]
     * secure_boot:
-        type: bool
-        description: Whether to enable or disable (U)EFI secure boot.
+        - type: bool
+        - description: Whether to enable or disable (U)EFI secure boot.
     * memory_reservation_lock:
-        type: bool
-        description:
-        - If set V(true), memory resource reservation for the virtual machine.
+        - type: bool
+        - description:
+            - If set true, memory resource reservation for the virtual machine.
     * max_connections:
-        type: int
-        description:
-        - Maximum number of active remote display connections for the virtual machines.
+        - type: int
+        - description:
+            - Maximum number of active remote display connections for the virtual machines.
     * mem_limit:
-        type: int
-        description:
-        - The memory utilization of a virtual machine will not exceed this limit.
-        - Unit is MB.
+        - type: int
+        - description:
+            - The memory utilization of a virtual machine will not exceed this limit.
+            - Units are in MB.
     * mem_reservation:
-        type: int
-        description: The amount of memory resource that is guaranteed available to the virtual machine.
-        aliases: [ 'memory_reservation' ]
+        - type: int
+        - description: The amount of memory resource that is guaranteed available to the virtual machine.
+        - aliases: [ 'memory_reservation' ]
     * mem_shares_level:
-        type: str
-        description:
-        - The allocation level of memory resources for the virtual machine.
-        choices: [ 'low', 'normal', 'high', 'custom' ]
-        version_added: '3.2.0'
+        - type: str
+        - description:
+            - The allocation level of memory resources for the virtual machine.
+        - choices: [ 'low', 'normal', 'high', 'custom' ]
+        - version_added: '3.2.0'
     * mem_shares:
-        type: int
-        description:
-        - The number of shares of memory allocated to this virtual machine
-        - mem_shares_level will automatically be set to 'custom'
-        version_added: '3.2.0'
+        - type: int
+        - description:
+            - The number of shares of memory allocated to this virtual machine
+            - `mem_shares_level` will automatically be set to 'custom'
+        - version_added: '3.2.0'
     * cpu_limit:
-        type: int
-        description:
-        - The CPU utilization of a virtual machine will not exceed this limit.
-        - Unit is MHz.
+        - type: int
+        - description:
+            - The CPU utilization of a virtual machine will not exceed this limit.
+            - Units are in MHz.
     * cpu_reservation:
-        type: int
-        description: The amount of CPU resource that is guaranteed available to the virtual machine.
+        - type: int
+        - description: The amount of CPU resource that is guaranteed available to the virtual machine.
     * version:
-        type: str
-        description:
-        - The Virtual machine hardware versions.
-        - Default is 10 (ESXi 5.5 and onwards).
-        - If set to V(latest), the specified virtual machine will be upgraded to the most current hardware version supported on the host.
-        - Please check VMware documentation for correct virtual machine hardware version.
-        - Incorrect hardware version may lead to failure in deployment. If hardware version is already equal to the given.
+        - type: str
+        - description:
+            - The Virtual machine hardware versions.
+            - Default is 10 (ESXi 5.5 and onwards).
+            - If set to latest, the specified virtual machine will be upgraded to the most current hardware version supported on the host.
+            - Please check VMware documentation for correct virtual machine hardware version.
+            - Incorrect hardware version may lead to failure in deployment. If hardware version is already equal to the given.
     * boot_firmware:
-        type: str
-        description: Choose which firmware should be used to boot the virtual machine.
-        choices: [ 'bios', 'efi' ]
+        - type: str
+        - description: Choose which firmware should be used to boot the virtual machine.
+        - choices: [ 'bios', 'efi' ]
     * nested_virt:
-        type: bool
-        description:
-        - Enable nested virtualization.
+        - type: bool
+        - description: Enable nested virtualization capabbilities.
     * virt_based_security:
-        type: bool
-        description:
-        - Enable Virtualization Based Security feature for Windows on ESXi 6.7 and later, from hardware version 14.
-        - Supported Guest OS are Windows 10 64 bit, Windows Server 2016, Windows Server 2019 and later.
-        - The firmware of virtual machine must be EFI and secure boot must be enabled.
-        - Virtualization Based Security depends on nested virtualization and Intel Virtualization Technology for Directed I/O.
-        - Deploy on unsupported ESXi, hardware version or firmware may lead to failure or deployed VM with unexpected configurations.
+        - type: bool
+        - description:
+            - Enable Virtualization Based Security feature for Windows on ESXi 6.7 and later, from hardware version 14.
+            - Supported Guest OS are Windows 10 64 bit, Windows Server 2016, Windows Server 2019 and later.
+            - The firmware of virtual machine must be EFI and secure boot must be enabled.
+            - Virtualization Based Security depends on nested virtualization and Intel Virtualization Technology for Directed I/O.
+            - Deploy on unsupported ESXi, hardware version or firmware may lead to failure or deployed VM with unexpected configurations.
     * iommu:
-        type: bool
-        description: Flag to specify if I/O MMU is enabled for this virtual machine.
+        - type: bool
+        - description: Flag to specify if I/O MMU is enabled for this virtual machine.
 
 - **provision_vm_state** (string):
-    Specify the state the virtual machine should be in.
-    If present and virtual machine exists, ensure the virtual machine configurations conforms to task arguments.
-    If absent and virtual machine exists, then the specified virtual machine is removed with it's associated components.
-    If set to one of poweredon, powered-on, poweredoff, powered-off, present, restarted, suspended and virtual machine does not exists, virtual machine is deployed with the given parameters.
-    If set to poweredon or powered-on and virtual machine exists with powerstate other than powered on, then the specified virtual machine is powered on.
-    If set to poweredoff or powered-off and virtual machine exists with powerstate other than powered off, then the specified virtual machine is powered off.
-    If set to restarted and virtual machine exists, then the virtual machine is restarted.
-    If set to suspended and virtual machine exists, then the virtual machine is set to suspended mode.
-    If set to shutdownguest or shutdown-guest and virtual machine exists, then the virtual machine is shutdown.
-    If set to rebootguest or reboot-guest and virtual machine exists, then the virtual machine is rebooted.
-    Choices:
-    - "absent"
-    - "poweredon"
-    - "powered-on"
-    - "poweredoff"
-    - "powered-off"
-    - "present" ← (default)
-    - "rebootguest"
-    - "reboot-guest"
-    - "restarted"
-    - "suspended"
-    - "shutdownguest"
-    - "shutdown-guest"
+    - Specify the state the virtual machine should be in.
+    - If set to `present` and the virtual machine exists, ensure the virtual machine configurations conform to task arguments.
+    - If set to `absent` and the virtual machine exists, then the specified virtual machine is removed with its associated components.
+    - If set to one of `poweredon`, `powered-on`, `poweredoff`, `powered-off`, `present`, `restarted` or `suspended` and virtual machine does not exist, the virtual machine is deployed with the given parameters.
+    - If set to `poweredon` or `powered-on` and the virtual machine exists with powerstate other than powered on, then the specified virtual machine is powered on.
+    - If set to `poweredoff` or `powered-off` and virtual machine exists with powerstate other than powered off, then the specified virtual machine is powered off.
+    - If set to `restarted` and the virtual machine exists, then the virtual machine is restarted.
+    - If set to `suspended` and the virtual machine exists, then the virtual machine is set to suspended mode.
+    - If set to `shutdownguest` or `shutdown-guest` and the virtual machine exists, then the virtual machine is shutdown.
+    - If set to `rebootguest` or `reboot-guest` and the virtual machine exists, then the virtual machine is rebooted.
+    - Choices:
+        - "absent"
+        - "poweredon"
+        - "powered-on"
+        - "poweredoff"
+        - "powered-off"
+        - "present" (default)
+        - "rebootguest"
+        - "reboot-guest"
+        - "restarted"
+        - "suspended"
+        - "shutdownguest"
+        - "shutdown-guest"
 
 - **provision_vm_state_change_timeout** (integer):
-    If the state=shutdownguest, by default the module will return immediately after sending the shutdown signal.
-    If this argument is set to a positive integer, the module will instead wait for the virtual machine to reach the poweredoff state.
-    The value sets a timeout in seconds for the module to wait for the state change.
-    Default: 0
+    - If `provision_vm_state` is `shutdownguest`, the module will return immediately after sending the shutdown signal.
+    - If this argument is set to a positive integer, the module will wait for the virtual machine to reach the poweredoff state.
+    - Default: 0
 
 - **provision_vm_vapp_properties** (list):
-    A list of vApp properties.
-    For full list of attributes and types refer to [vApp Properties info](https://vdc-download.vmware.com/vmwb-repository/dcr-public/184bb3ba-6fa8-4574-a767-d0c96e2a38f4/ba9422ef-405c-47dd-8553-e11b619185b2/SDK/vsphere-ws/docs/ReferenceGuide/vim.vApp.PropertyInfo.html)
-    Element keys:
+    - A list of vApp properties.
+    - For full list of attributes and types refer to [vApp Properties info](https://vdc-download.vmware.com/vmwb-repository/dcr-public/184bb3ba-6fa8-4574-a767-d0c96e2a38f4/ba9422ef-405c-47dd-8553-e11b619185b2/SDK/vsphere-ws/docs/ReferenceGuide/vim.vApp.PropertyInfo.html)
+    - Each element in the provided list may have the following attributes:
     * id:
-      type: str
-      description:
-      - Property ID.
-      - Required per entry.
+        - type: str
+        - description:
+            - Property ID.
+            - Required per entry.
     * value:
-        type: str
-        description:
-        - Property value.
+        - type: str
+        - description:
+            - Property value.
     * type:
-        type: str
-        description:
-        - Value type, string type by default.
+        - type: str
+        - description:
+            - Value type, string type by default.
     * operation:
-        type: str
-        description:
-        - The C(remove) attribute is required only when removing properties.
+        - type: str
+        - description:
+            - Set to `remove` when removing properties.
 
 - **provision_vm_wait_for_customization** (boolean):
-    Wait until vCenter detects all guest customizations as successfully completed.
-    When enabled, the VM will automatically be powered on.
-    If vCenter does not detect guest customization start or succeed, failed events after time wait_for_customization_timeout parameter specified, warning message will be printed and task result is fail.
-    Choices:
-    - false ← (default)
-    - true
+    - Wait until vCenter detects all guest customizations completed successfully.
+    - When enabled, the VM will automatically be powered on.
+    - If vCenter does not detect guest customization or failed events after time `provision_vm_wait_for_customization_timeout` parameter specified, warning message will be printed and the role will fail.
+    - Choices:
+        - false
+        - true
 
 - **provision_vm_wait_for_customization_timeout** (integer):
-    Define a timeout (in seconds) for the wait_for_customization parameter.
-    Be careful when setting this value since the time guest customization took may differ among guest OSes.
-    Default: 3600
+    - Define a timeout (in seconds) for the `provision_vm_wait_for_customization` parameter.
+    - Be careful when setting this value since the guest customization time may differ among guest OSes.
+    - Default: 3600
 
 - **provision_vm_wait_for_ip_address** (boolean):
-    Wait until vCenter detects an IP address for the virtual machine.
-    This requires vmware-tools (vmtoolsd) to properly work after creation.
-    vmware-tools needs to be installed on the given virtual machine in order to work with this parameter.
-    Choices:
-    - false ← (default)
-    - true
+    - Wait until vCenter detects an IP address for the virtual machine.
+    - This requires vmware-tools (vmtoolsd) on the virtual machine.
+    - Choices:
+        - false (default)
+        - true
 
 - **provision_vm_wait_for_ip_address_timeout** (integer):
-    Define a timeout (in seconds) for the wait_for_ip_address parameter.
-    Default: 300
+    - Define a timeout (in seconds) for the `provision_vm_wait_for_ip_address` parameter.
+    - Default: 300
 
 
 - **provision_vm_networks** (list):
-    A list of networks (in the order of the NICs).
-    Removing NICs is not allowed, while reconfiguring the virtual machine.
-    All parameters and VMware object names are case sensitive.
-    The type, ip, netmask, gateway, domain, dns_servers options don't set to a guest when creating a blank new virtual machine. They are set by the customization via vmware-tools. If you want to set the value of the options to a guest, you need to clone from a template with installed OS and vmware-tools(also Perl when Linux).
-    Element keys:
+    - A list of network cards to attach (in the order of the NICs).
+    - Removing NICs is not allowed while reconfiguring the virtual machine.
+    - All parameters and VMware object names are case sensitive.
+    - The `type`, `ip`, `netmask`, `gateway`, `domain`, and `dns_servers` options are not directly applied to the virtual machine. They are used when customization is run via vmware-tools. See `provision_vm_customization`.
+    - Each element in the list of networks can have the following attributes:
     * name:
-        type: str
-        description:
-        - Name of the portgroup or distributed virtual portgroup for this interface.
-        - Required per entry.
-        - When specifying distributed virtual portgroup make sure given O(esxi_hostname) or O(cluster) is associated with it.
+        - type: str
+        - description:
+            - Name of the portgroup or distributed virtual portgroup for this interface.
+            - Required per entry.
+            - When specifying distributed virtual portgroup make sure the given `provision_vm_esxi_hostname` or `provision_vm_cluster` is associated with it.
     * vlan:
-        type: int
-        description:
-        - VLAN number for this interface.
-        - Required per entry.
+        - type: int
+        - description:
+            - VLAN number for this interface.
+            - Required per entry.
     * device_type:
-        type: str
-        description:
-        - Virtual network device.
-        - Valid value can be one of C(e1000), C(e1000e), C(pcnet32), C(vmxnet2), C(vmxnet3), C(sriov).
-        - C(vmxnet3) is default.
-        - Optional per entry.
-        - Used for virtual hardware.
+        - type: str
+        - description:
+            - Virtual network device type.
+            - Default is vmxnet3
+        - Choices: [e1000, e1000e, pcnet32, vmxnet2, vmxnet3, sriov]
     * mac:
-        type: str
-        description:
-        - Customize MAC address.
-        - Optional per entry.
-        - Used for virtual hardware.
+        - type: str
+        - description:
+            - Customize MAC address.
+            - Optional per entry.
     * dvswitch_name:
-        type: str
-        description:
-        - Name of the distributed vSwitch.
-        - Optional per entry.
-        - Used for virtual hardware.
+        - type: str
+        - description:
+            - Name of the distributed vSwitch.
+            - Optional per entry.
     * type:
-        type: str
-        description:
-        - Type of IP assignment.
-        - Valid values are one of C(dhcp), C(static).
-        - C(dhcp) is default.
-        - Optional per entry.
-        - Used for OS customization.
+        - type: str
+        - description:
+            - Type of IP assignment.
+            - Default is dhcp
+        - choices: [dhcp, static]
     * ip:
-        type: str
-        description:
-        - Static IP address. Implies C(type=static).
-        - Optional per entry.
-        - Used for OS customization.
+        - type: str
+        - description:
+            - Static IP address. Only used if `type` is `static`
+            - Optional per entry.
     * netmask:
-        type: str
-        description:
-        - Static netmask required for C(ip).
-        - Optional per entry.
-        - Used for OS customization.
+        - type: str
+        - description:
+            - Static netmask required if `ip` is set.
+            - Optional per entry.
     * gateway:
-        type: str
-        description:
-        - Static gateway.
-        - Optional per entry.
-        - Used for OS customization.
+        - type: str
+        - description:
+            - Static gateway
+            - Optional per entry.
     * typev6:
-        version_added: '4.1.0'
-        type: str
-        description:
-        - Type of IP assignment.
-        - Valid values are one of C(dhcp), C(static).
-        - C(dhcp) is default.
-        - Optional per entry.
-        - Used for OS customization.
+        - version_added: '4.1.0'
+        - type: str
+        - description:
+            - Type of IPv6 assignment.
+            - Optional per entry.
+            - Default is dhcp
+        - choices: [static, dhcp]
     * ipv6:
-        version_added: '4.1.0'
-        type: str
-        description:
-        - Static IP address. Implies C(type=static).
-        - Optional per entry.
-        - Used for OS customization.
+        - version_added: '4.1.0'
+        - type: str
+        - description:
+            - Static IP address. Only used if `type` is `static`
+            - Optional per entry.
     * netmaskv6:
-        version_added: '4.1.0'
-        type: str
-        description:
-        - Static netmask required for C(ip).
-        - Optional per entry.
-        - Used for OS customization.
+        - version_added: '4.1.0'
+        - type: str
+        - description:
+            - Static netmask required if `ipv6` is set.
+            - Optional per entry.
     * gatewayv6:
-        version_added: '4.1.0'
-        type: str
-        description:
-        - Static gateway.
-        - Optional per entry.
-        - Used for OS customization.
+        - version_added: '4.1.0'
+        - type: str
+        - description:
+            - Static gateway
+            - Optional per entry.
     * dns_servers:
-        type: str
-        description:
-        - DNS servers for this network interface (Windows).
-        - Optional per entry.
-        - Used for OS customization.
+        - type: str
+        - description:
+            - DNS servers for this network interface (Windows).
+            - Optional per entry.
     * domain:
-        type: str
-        description:
-        - Domain name for this network interface (Windows).
-        - Optional per entry.
-        - Used for OS customization.
+        - type: str
+        - description:
+            - Domain name for this network interface (Windows).
+            - Optional per entry.
     * connected:
-        type: bool
-        description:
-        - Indicates whether the NIC is currently connected.
+        - type: bool
+        - description:
+            - Indicates whether the NIC is currently connected.
     * start_connected:
-        type: bool
-        description:
-        - Specifies whether or not to connect the device when the virtual machine starts.
+        - type: bool
+        - description:
+            - Specifies whether or not to connect the device when the virtual machine starts.
 
 - **provision_vm_nvdimm** (dictionary):
-    Add or remove a virtual NVDIMM device to the virtual machine.
-    VM virtual hardware version must be 14 or higher on vSphere 6.7 or later.
-    Verify that guest OS of the virtual machine supports PMem before adding virtual NVDIMM device.
-    Verify that you have the Datastore.Allocate space privilege on the virtual machine.
-    Make sure that the host or the cluster on which the virtual machine resides has available PMem resources.
-    To add or remove virtual NVDIMM device to the existing virtual machine, it must be in power off state.
-    Keys:
+    - Add or remove a virtual NVDIMM device to the virtual machine.
+    - VM virtual hardware version must be 14 or higher on vSphere 6.7 or later.
+    - Verify that guest OS of the virtual machine supports PMem before adding virtual NVDIMM device.
+    - Verify that you have the Datastore.Allocate space privilege on the virtual machine.
+    - Make sure that the host or the cluster on which the virtual machine resides has available PMem resources.
+    - To add or remove virtual NVDIMM device to the existing virtual machine, it must be in power off state.
+    - The dictionary should have the following structure:
     * state:
-         type: str
-         description:
-         - If set to V(absent), then the NVDIMM device with specified O(nvdimm.label) will be removed.
-         choices: ['present', 'absent']
+        - type: str
+        - description:
+            - If set to `absent`, then the NVDIMM device with specified `label` will be removed.
+        - choices: ['present', 'absent']
     * size_mb:
-        type: int
-        description: Virtual NVDIMM device size in MB.
-        default: 1024
+        - type: int
+        - description: Virtual NVDIMM device size in MB.
+        - default: 1024
     * label:
-         type: str
-         description:
-         - The label of the virtual NVDIMM device to be removed or configured, e.g., "NVDIMM 1".
-         - 'This parameter is required when O(nvdimm.state=absent), or O(nvdimm.state=present) to reconfigure NVDIMM device
-           size. When add a new device, please do not set.'
+        - type: str
+        - description:
+            - The label of the virtual NVDIMM device to be removed or configured, e.g., "NVDIMM 1".
+            - This parameter is required when `provision_vm_nvdimm.state` is `absent` or `present` to reconfigure NVDIMM device
+              size. When add a new device, please do not set.
 
 - **provision_vm_use_instance_uuid** (boolean):
-    Whether to use the VMware instance UUID rather than the BIOS UUID.
-    Choices:
-    - false ← (default)
-    - true
+    - Whether to use the VMware instance UUID instead of the BIOS UUID.
+    - Choices:
+        - false (default)
+        - true
 
 - **provision_vm_name_match** (string):
-
-    If multiple virtual machines matching the name, use the first or last found.
-    Choices:
-    - "first" ← (default)
-    - "last"
+    - If multiple virtual machines matching the name, use the first or last found.
+    - Choices:
+        - "first" (default)
+        - "last"
 
 - **provision_vm_is_template** (bool):
-    If true, the VM will be created as a template instead of a regular VM.
-    Default: false
+    - If true, the VM will be created as a template instead of a regular VM.
+    - Default: false
 
-## Dependencies
-
-N/A
 
 ## Example Playbook
 
@@ -806,7 +776,7 @@ ansible-playbook playbook.yml -e "@vars.yml"
 
 GNU General Public License v3.0 or later
 
-See [LICENCE](https://github.com/ansible-collections/cloud.vmware_ops/blob/main/LICENSE) to see the full text.
+See [LICENSE](https://github.com/ansible-collections/cloud.vmware_ops/blob/main/LICENSE) to see the full text.
 
 ## Author Information
 

--- a/roles/provision_vm/README.md
+++ b/roles/provision_vm/README.md
@@ -350,7 +350,7 @@ N/A
         - choices: ['buslogic', 'lsilogic', 'lsilogicsas', 'paravirtual', 'sata', 'nvme']
         - description:
             - Type of disk controller.
-            - Set this type on not supported ESXi or VM hardware version will lead to failure in deployment.
+            - Setting this type on not supported ESXi or VM hardware version will lead to deployment failure.
             - If set to `sata` type, please make sure `controller_number` and `unit_number` do not conflict with sata values in `provison_vm_cdrom`.
     * controller_number:
         - type: int
@@ -383,7 +383,7 @@ N/A
 
 - **provision_vm_force** (boolean):
     - Ignore warnings and complete the actions.
-    - This parameter is useful while removing virtual machine which is powered on state.
+    - This parameter is useful while removing a virtual machine that is the powered on state.
     - Choices:
         - false
         - true
@@ -501,7 +501,7 @@ N/A
         - choices: [ 'bios', 'efi' ]
     * nested_virt:
         - type: bool
-        - description: Enable nested virtualization capabbilities.
+        - description: Enable nested virtualization capabilities.
     * virt_based_security:
         - type: bool
         - description:
@@ -509,7 +509,7 @@ N/A
             - Supported Guest OS are Windows 10 64 bit, Windows Server 2016, Windows Server 2019 and later.
             - The firmware of virtual machine must be EFI and secure boot must be enabled.
             - Virtualization Based Security depends on nested virtualization and Intel Virtualization Technology for Directed I/O.
-            - Deploy on unsupported ESXi, hardware version or firmware may lead to failure or deployed VM with unexpected configurations.
+            - Deploying on unsupported ESXi, hardware version or firmware may lead to failure or deployed VM with unexpected configurations.
     * iommu:
         - type: bool
         - description: Flag to specify if I/O MMU is enabled for this virtual machine.
@@ -712,7 +712,7 @@ N/A
         - description:
             - The label of the virtual NVDIMM device to be removed or configured, e.g., "NVDIMM 1".
             - This parameter is required when `provision_vm_nvdimm.state` is `absent` or `present` to reconfigure NVDIMM device
-              size. When add a new device, please do not set.
+              size. When adding a new device, please do not set.
 
 - **provision_vm_use_instance_uuid** (boolean):
     - Whether to use the VMware instance UUID instead of the BIOS UUID.

--- a/roles/provision_vm/README.md
+++ b/roles/provision_vm/README.md
@@ -41,7 +41,7 @@ N/A
 - **provision_vm_name**  (string, Required):
     - Name of the virtual machine to manage.
     - Virtual machine names in vCenter are not necessarily unique which may be problematic.
-      If multiple virtual machines with same name exists, then `provision_vm_folder` is required parameter to
+      If multiple virtual machines with the same name exist, then `provision_vm_folder` is required parameter to
       identify uniqueness of the virtual machine. You can also set `provision_vm_name_match` to control how multiple matching VM names are handled.
     - The parameter is required if the virtual machine does not already exist.
     - This parameter is case sensitive.
@@ -50,7 +50,7 @@ N/A
     - The instance UUID of the virtual machine to manage.
     - This is required if `provision_vm_name` is not supplied.
     - Note that a supplied UUID will be ignored on virtual machine creation, as VMware creates the UUID internally.
-      If virtual machine does not exists, then this parameter is ignored.
+      If virtual machine does not exist, then this parameter is ignored.
 
 - **provision_vm_cluster** (String):
     - The name of the cluster where the virtual machine will run.
@@ -301,7 +301,7 @@ N/A
     * size:
         - description:
             - Disk storage size.
-            - You should include the storage unit like 100kb, 100mb, etc
+            - You should include the storage unit such as 100kb, 100mb, etc
         - type: str
     * size_kb:
         - description: Disk storage size in kb.
@@ -342,9 +342,9 @@ N/A
         - choices: ['persistent', 'independent_persistent', 'independent_nonpersistent']
         - description:
             - Type of disk mode.
-            - If `persistent` specified, changes are immediately and permanently written to the virtual disk. This is default.
-            - If `independent_persistent` specified, same as persistent, but not affected by snapshots.
-            - If `independent_nonpersistent` specified, changes to virtual disk are made to a redo log and discarded at power off, but not affected by snapshots.
+            - If `persistent` is specified, changes are immediately and permanently written to the virtual disk. This is default.
+            - If `independent_persistent` is specified, same as persistent, but not affected by snapshots.
+            - If `independent_nonpersistent` is specified, changes to virtual disk are made to a redo log and discarded at power off, but not affected by snapshots.
     * controller_type:
         - type: str
         - choices: ['buslogic', 'lsilogic', 'lsilogicsas', 'paravirtual', 'sata', 'nvme']

--- a/roles/snapshot_management/README.md
+++ b/roles/snapshot_management/README.md
@@ -107,7 +107,7 @@ N/A
   - If set to `true` and the virtual machine is powered on, it will quiesce the file system in the virtual machine.
   - Note that VMware Tools are required for this flag.
   - If the virtual machine is powered off or VMware Tools are not available, then this flag is ignored.
-  - If the virtual machine does not provide capability to take quiesce snapshot, then this flag ignored.
+  - If the virtual machine does not provide capability to take quiesce snapshot, then this flag is ignored.
   - default: false
 
 - **snapshot_management_memory_dump**:

--- a/roles/snapshot_management/README.md
+++ b/roles/snapshot_management/README.md
@@ -1,9 +1,10 @@
 # snapshot_management
-A role to manages virtual machines snapshots in vCenter.
+A role to manage virtual machines snapshots in vCenter.
 This role can be used to create, delete and update snapshot(s) of the given virtual machine.
 
 
-## Requirements 
+## Dependencies
+
 N/A
 
 
@@ -22,108 +23,108 @@ N/A
   - Allows connection when SSL certificates are not valid. Set to false when certificates are not trusted.
 
 - **snapshot_management_port** (integer):
-    The port number of the vSphere vCenter or ESXi server.
-    If the value is not specified in the task, the value of environment variable VMWARE_PORT will be used instead.
-    Default: 443
+  - The port number of the vSphere vCenter or ESXi server.
+  - If the value is not specified in the task, the value of environment variable VMWARE_PORT will be used instead.
+  - Default: 443
 
 - **snapshot_management_proxy_host** (string):
-    Address of a proxy that will receive all HTTPS requests and relay them.
-    The format is a hostname or a IP.
-    If the value is not specified in the task, the value of environment variable VMWARE_PROXY_HOST will be used instead.
+  - The address of a proxy that will receive all HTTPS requests and relay them.
+  - The format is a hostname or an IP.
+  - If the value is not specified in the task, the value of environment variable VMWARE_PROXY_HOST will be used instead.
 
 - **snapshot_management_proxy_port** (integer):
-    Port of the HTTP proxy that will receive all HTTPS requests and relay them.
-    If the value is not specified in the task, the value of environment variable VMWARE_PROXY_PORT will be used instead.
+  - The port of the HTTP proxy that will receive all HTTPS requests and relay them.
+  - If the value is not specified in the task, the value of environment variable VMWARE_PROXY_PORT will be used instead.
 
 ### Manage a VM snapshot
-- **snapshot_management_state**: 
+- **snapshot_management_state**:
   - Manage snapshot(s) attached to a specific virtual machine.
-  - If set to C(present) and snapshot absent, then will create a new snapshot with the given name.
-     - If set to C(present) and snapshot present, then no changes are made.
-     - If set to C(absent) and snapshot present, then snapshot with the given name is removed.
-     - If set to C(absent) and snapshot absent, then no changes are made.
-     - If set to C(revert) and snapshot present, then virtual machine state is reverted to the given snapshot.
-     - If set to C(revert) and snapshot absent, then no changes are made.
-     - If set to C(remove_all) and snapshot(s) present, then all snapshot(s) will be removed.
-     - If set to C(remove_all) and snapshot(s) absent, then no changes are made.
+  - If set to `present` and the snapshot is absent, then a new snapshot will be created with the given name.
+  - If set to `present` and the snapshot is present, then no changes are made.
+  - If set to `absent` and the snapshot is present, then the snapshot with the given name is removed.
+  - If set to `absent` and the snapshot is absent, then no changes are made.
+  - If set to `revert` and the snapshot is present, then virtual machine state is reverted to the given snapshot.
+  - If set to `revert` and the snapshot is absent, then no changes are made.
+  - If set to `remove_all` and the snapshot(s) are present, then all snapshot(s) will be removed.
+  - If set to `remove_all` and the snapshot(s) are absent, then no changes are made.
   - choices: ['present', 'absent', 'revert', 'remove_all']
   - default: 'present'
-  
+
 - **snapshot_management_vm_name**:
   - Name of the virtual machine to work with.
-  - This is required parameter, if C(uuid) or C(moid) is not supplied.
-  - This parameter required together with C(snapshot_management_folder).
+  - This is required parameter, if `snapshot_management_uuid` or `snapshot_management_moid` are not supplied.
+  - This parameter is required together with `snapshot_management_folder`.
 
-- **snapshot_management_vm_name_match**: 
-  - If multiple VMs matching the name, use the first or last found.
+- **snapshot_management_vm_name_match**:
+  - If multiple VMs have the same name, use the first or last found.
   - default: 'first'
   - choices: ['first', 'last']
 
-- **snapshot_management_uuid**: 
-  - UUID of the instance to manage if known, this is VMware's BIOS UUID by default.
-  - This is required if C(name) or C(moid) parameter is not supplied.
+- **snapshot_management_uuid**:
+  - UUID of the instance to manage if known. This is VMware's BIOS UUID by default.
+  - This is required if neither `snapshot_management_vm_name` nor `snapshot_management_moid` are supplied.
 
-- **snapshot_management_moid**: 
-  - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
-  - This is required if C(name) or C(uuid) is not supplied.
+- **snapshot_management_moid**:
+  - Managed Object ID of the instance to manage if known. This is a unique identifier within a single vCenter instance.
+  - This is required if neither `snapshot_management_vm_name` nor `snapshot_management_uuid` are supplied.
 
-- **snapshot_management_use_instance_uuid**: 
+- **snapshot_management_use_instance_uuid**:
   - Whether to use the VMware instance UUID rather than the BIOS UUID.
   - default: false
 
-- **snapshot_management_folder**: 
-  - Destination folder, absolute or relative path to find an existing guest.
-  - This parameter required together with C(snapshot_management_vm_name).
-  - The folder should include the datacenter. ESX's datacenter is ha-datacenter.
-  - 'Examples:'
-    - '   folder: /ha-datacenter/vm'
-    - '   folder: ha-datacenter/vm'
-    - '   folder: /datacenter1/vm'
-    - '   folder: datacenter1/vm'
-    - '   folder: /datacenter1/vm/folder1'
-    - '   folder: datacenter1/vm/folder1'
-    - '   folder: /folder1/datacenter1/vm'
-    - '   folder: folder1/datacenter1/vm'
-    - '   folder: /folder1/datacenter1/vm/folder2'
+- **snapshot_management_folder**:
+  - Destination folder. The absolute or relative path to find an existing guest.
+  - This parameter is required together with `snapshot_management_vm_name`.
+  - The folder should include the datacenter. ESXi's default datacenter is ha-datacenter.
+  - Examples:
+    - /ha-datacenter/vm
+    - ha-datacenter/vm
+    - /datacenter1/vm
+    - datacenter1/vm
+    - datacenter1/vm/folder1
+    - datacenter1/vm/folder1
+    - /folder1/datacenter1/vm
+    - /folder1/datacenter1/vm
+    - /folder1/datacenter1/vm/folder2
 
-- **snapshot_management_datacenter**: 
+- **snapshot_management_datacenter**:
   - Destination datacenter for the deploy operation.
   - required: true
 
-- **snapshot_management_snapshot_name**: 
+- **snapshot_management_snapshot_name**:
   - Sets the snapshot name to manage.
-  - This param or C(snapshot_id) is required only if state is not C(remove_all)
+  - This param or `snapshot_management_snapshot_id` are required only if state is not `remove_all`
 
-- **snapshot_management_snapshot_id**: 
+- **snapshot_management_snapshot_id**:
   - Sets the snapshot ID to manage.
-  - This param is available when state is C(absent).
+  - This param is used when state is `absent`.
 
-- **snapshot_management_description**: 
-  - Define an arbitrary description to attach to snapshot.
+- **snapshot_management_description**:
+  - Define an arbitrary description to attach to the snapshot.
   - default: ''
 
-- **snapshot_management_quiesce**: 
-  - If set to C(true) and virtual machine is powered on, it will quiesce the file system in the virtual machine.
+- **snapshot_management_quiesce**:
+  - If set to `true` and the virtual machine is powered on, it will quiesce the file system in the virtual machine.
   - Note that VMware Tools are required for this flag.
-  - If virtual machine is powered off or VMware Tools are not available, then this flag is set to C(false).
-  - If virtual machine does not provide capability to take quiesce snapshot, then this flag is set to C(false).
+  - If the virtual machine is powered off or VMware Tools are not available, then this flag is ignored.
+  - If the virtual machine does not provide capability to take quiesce snapshot, then this flag ignored.
   - default: false
 
-- **snapshot_management_memory_dump**: 
-  - If set to C(true), memory dump of virtual machine is also included in snapshot.
-  - Note that memory snapshots take time and resources, this will take longer time to create.
-  - If virtual machine does not provide capability to take memory snapshot, then this flag is set to C(false).
+- **snapshot_management_memory_dump**:
+  - If set to `true`, a memory dump of the virtual machine is also included in snapshot.
+  - Note that memory snapshots take time and resources. This will take longer time to create.
+  - If virtual machine does not provide capability to take memory snapshot, then this flag is ignored.
   - default: false
 
-- **snapshot_management_remove_children**: 
-  - If set to C(true) and state is set to C(absent), then the entire snapshot subtree is set for removal.
+- **snapshot_management_remove_children**:
+  - If set to `true` and state is set to `absent`, then the entire snapshot subtree is set for removal.
   - default: false
 
-- **snapshot_management_new_snapshot_name**: 
-  - Value to rename the existing snapshot to.
+- **snapshot_management_new_snapshot_name**:
+  - Rename the existing snapshot to this value.
 
-- **snapshot_management_new_description**: 
-  - Value to change the description of an existing snapshot to.
+- **snapshot_management_new_description**:
+  - Change the description of the existing snapshot to this value.
 
 
 ## Dependencies
@@ -227,7 +228,7 @@ ansible-playbook playbook.yml -e "@vars.yml"
 
 GNU General Public License v3.0 or later
 
-See [LICENCE](https://github.com/ansible-collections/cloud.vmware_ops/blob/main/LICENSE) to see the full text.
+See [LICENSE](https://github.com/ansible-collections/cloud.vmware_ops/blob/main/LICENSE) to see the full text.
 
 ## Author Information
 

--- a/roles/system_settings/README.md
+++ b/roles/system_settings/README.md
@@ -2,7 +2,7 @@
 
 A role to define system settings for vCenter.
 
-## Requirements
+## Dependencies
 
 N/A
 
@@ -45,10 +45,10 @@ N/A
   - List of DNS domains to add/set.
 
 - **system_settings_dns_mode_append**
-  - If `true` items from `system_settings_dns_domains` and `system_settings_dns_servers` will be added to already configured DNS domains/servers. If `false` domains/servers will be overriden.
+  - If `true` items from `system_settings_dns_domains` and `system_settings_dns_servers` will be added to already configured DNS domains/servers. If `false` domains/servers will be overridden.
 
 - **system_settings_dns_hostname**:
-  - Set the hostname of the vcenter.
+  - Set the hostname of the vCenter.
 
 #### NTP
 Note: NTP service will be restarted if configuration is changed.
@@ -95,9 +95,6 @@ Note: NTP service will be restarted if configuration is changed.
 - **system_settings_firewall_rules_append**:
   - If `false` the rules overwrites the existing firewall rules and creates a new rule list. If `true` we append the rules to existing rules. Default is `true`.
 
-## Dependencies
-
-- vmware.vmware_rest
 
 ## Example Playbook
 ```yaml
@@ -113,7 +110,7 @@ Note: NTP service will be restarted if configuration is changed.
 
 GNU General Public License v3.0 or later
 
-See [LICENCE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
+See [LICENSE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
 
 ## Author Information
 

--- a/roles/system_settings/README.md
+++ b/roles/system_settings/README.md
@@ -93,7 +93,7 @@ Note: NTP service will be restarted if configuration is changed.
   - Set the ordered list of firewall rules to allow or deny traffic from one or more incoming IP addresses. Within the list of traffic rules, rules are processed in order of appearance, from top to bottom.
 
 - **system_settings_firewall_rules_append**:
-  - If `false` the rules overwrites the existing firewall rules and creates a new rule list. If `true` we append the rules to existing rules. Default is `true`.
+  - If `false` the rules overwrite the existing firewall rules and creates a new rule list. If `true` we append the rules to existing rules. Default is `true`.
 
 
 ## Example Playbook

--- a/roles/vcenter_host_connection/README.md
+++ b/roles/vcenter_host_connection/README.md
@@ -1,6 +1,6 @@
 # vcenter_host_connection
 
-Add, remove, connect, disconnect, or reconnect an ESXi host from a VCenter
+Add, remove, connect, disconnect, or reconnect an ESXi host from a vCenter
 
 ## Dependencies
 

--- a/roles/vcenter_host_connection/README.md
+++ b/roles/vcenter_host_connection/README.md
@@ -2,27 +2,27 @@
 
 Add, remove, connect, disconnect, or reconnect an ESXi host from a VCenter
 
-## Requirements
+## Dependencies
 
-pyvomi
+N/A
 
 ## Role Variables
 
 ### Auth
 - **vcenter_host_connection_hostname**:
-  - str, The hostname of the vcenter to which you want to connect. Required
+  - str, The hostname of the vCenter to which you want to connect. Required
 
 - **vcenter_host_connection_username**:
-  - str, The username to use to authenticate to the vcenter to which you want to connect. Required
+  - str, The username to use to authenticate to the vCenter to which you want to connect. Required
 
 - **vcenter_host_connection_password**:
-  - str, The password to use to authenticate to the esxi or vcenter to which you want to connect. Required
+  - str, The password to use to authenticate to the ESXi or vCenter to which you want to connect. Required
 
 - **vcenter_host_connection_validate_certs**:
-  - bool, If true then certificates will be validated when connecting to the vcenter for auth. Optional.
+  - bool, If true then certificates will be validated when connecting to the vCenter for auth. Optional.
 
 - **vcenter_host_connection_port**:
-  - int, The port of the vcenter to which you want to connect. Optional.
+  - int, The port of the vCenter to which you want to connect. Optional.
 
 ### Placement
 - **vcenter_host_connection_folder**:
@@ -38,13 +38,13 @@ pyvomi
 - **vcenter_host_connection_state**:
   - str, The connection state of the ESXi host that you want to set. Default is `present`
   - If set to `present`, add the host if host is absent, or update the location of the host if host already exists.
-  - If set to `absent`, remove the host if host is present, or do nothing if host already does not exists.
+  - If set to `absent`, remove the host if host is present, or do nothing if host already does not exist.
   - If set to `add_or_reconnect`, add the host if it's absent else reconnect it and update the location.
   - If set to `reconnect`, then reconnect the host if it's present and update the location.
   - If set to `disconnected`, disconnect the host if the host already exists.
 
 - **vcenter_host_connection_add_connected**:
-  - bool, If true then the host will be connected as soon as its added to vcenter. Optional
+  - bool, If true then the host will be connected as soon as it's added to vCenter. Optional
 
 - **vcenter_host_connection_esxi_hostname**:
   - str, The hostname of the ESXi host that you want to manage. Required
@@ -59,10 +59,10 @@ pyvomi
   - str, The SSL thumbprint for the ESXi host that you want to manage. Optional.
 
 - **vcenter_host_connection_fetch_ssl_thumbprint**:
-  - bool, If true, the ESXi host thumprint will be fetched and trusted prior to adding. Optional.
+  - bool, If true, the ESXi host thumbprint will be fetched and trusted prior to adding. Optional.
 
 - **vcenter_host_connection_force_connection**:
-  - bool, If true, the connection status will be forced even if the host is managed by another vcenter. Optional
+  - bool, If true, the connection status will be forced even if the host is managed by another vCenter. Optional
 
 - **vcenter_host_connection_reconnect_disconnected**:
   - bool, Reconnect disconnected hosts, if the state is present and the host already exists. Optional
@@ -74,10 +74,6 @@ pyvomi
 - **vcenter_host_connection_proxy_port**:
   - str, The port of a proxy host that should be used for all HTTPs communication by the role. Optional
 
-
-## Dependencies
-
-- NA
 
 ## Example Playbook
 ```yaml
@@ -116,7 +112,7 @@ License
 
 GNU General Public License v3.0 or later
 
-See [LICENCE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
+See [LICENSE](https://github.com/ansible-collections/cloud.aws_troubleshooting/blob/main/LICENSE) to see the full text.
 
 Author Information
 ------------------

--- a/tests/integration/targets/vmware_ops_cluster_settings_test/vars.yml
+++ b/tests/integration/targets/vmware_ops_cluster_settings_test/vars.yml
@@ -24,6 +24,6 @@ cluster_settings_vcls_allowed_datastores:
   - LocalDS_0
 #
 # Disabled vSAN tests because they require an SDK
-# from VMWare that is not publically accessible
+# from VMWare that is not publicly accessible
 # vSAN
 # cluster_settings_vsan_enable: False

--- a/tests/integration/targets/vmware_ops_provision_vm_test/tasks/update_vm.yml
+++ b/tests/integration/targets/vmware_ops_provision_vm_test/tasks/update_vm.yml
@@ -33,7 +33,7 @@
     switch: "{{ vswitch_name }}"
     portgroup: "{{ portgroup_name }}"
 
-- name: Wait for {{ portgroup_name }} to propegate to all hosts
+- name: Wait for {{ portgroup_name }} to propagate to all hosts
   ansible.builtin.pause:
     seconds: 30
 


### PR DESCRIPTION
This fixes a ton of typos and grammatical errors throughout the collection. I used the document generated by QE to guide the changes.

I also tried to update the provision_vm documentation to be a bit more readable since that was noted as being particularly difficult by QE. I think its because there are so many options that were copied from the community module, leading to weird syntax.

I also updated our role dependency docs to match other validated content collections. They use that section to identify pre-req steps, system requirements, and other miscellaneous dependencies rather than python or collection deps.