### PR TITLE
Mm feature/fix export vm as ovf vars

### DIFF
--- a/changelogs/fragments/105-fix-variables in-export-vm-as-ovf.yml
+++ b/changelogs/fragments/105-fix-variables in-export-vm-as-ovf.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - export_vm_as_ovf - Removed duplicate vars in docs, changed datacenter var name to match other roles while maintaining backwards compat

--- a/roles/export_vm_as_ovf/README.md
+++ b/roles/export_vm_as_ovf/README.md
@@ -20,18 +20,13 @@ N/A
 - **export_vm_as_ovf_validate_certs**
   - Allows connection when SSL certificates are not valid. Set to false when certificates are not trusted.
 
-- **export_vm_as_ovf_cluster_name**:
-  - The name of the cluster in vSphere vCenter that contains the VM.
-
-- **export_vm_as_ovf_datacenter_name**:
-  - The name of the datacenter in vSphere vCenter which contains the VM.
-
 - **export_vm_as_ovf_port**:
   - str or int, The port used to authenticate to the vSphere vCenter that contains the VM.
 
 ### VM Options
-- **export_vm_as_ovf_vm_datacenter**:
-  - str, The name of the datacenter that contains the VM that should be exported.
+- **export_vm_as_ovf_datacenter**:
+  - The name of the datacenter in vSphere vCenter which contains the VM.
+  - Aliases: [export_vm_as_ovf_datacenter_name]
 
 - **export_vm_as_ovf_vm_folder**:
   - str, The vCenter folder that contains the VM that should be exported. This should be the full folder path

--- a/roles/export_vm_as_ovf/tasks/main.yml
+++ b/roles/export_vm_as_ovf/tasks/main.yml
@@ -13,6 +13,11 @@
     quiet: true
     fail_msg: Variable must be set when using this role.
 
+- name: Map Variable Aliases to Documented Names
+  ansible.builtin.set_fact:
+    export_vm_as_ovf_vm_datacenter: "{{ export_vm_as_ovf_vm_datacenter_name }}"
+  when: export_vm_as_ovf_vm_datacenter_name is defined
+
 - name: Export VM As OVF
   community.vmware.vmware_export_ovf:
     hostname: "{{ export_vm_as_ovf_hostname }}"
@@ -23,7 +28,7 @@
     proxy_host: "{{ export_vm_as_ovf_proxy_host | default(omit) }}"
     proxy_port: "{{ export_vm_as_ovf_proxy_port | default(omit) }}"
 
-    datacenter: "{{ export_vm_as_ovf_vm_datacenter_name | default(omit) }}"
+    datacenter: "{{ export_vm_as_ovf_vm_datacenter | default(omit) }}"
     folder: "{{ export_vm_as_ovf_vm_folder | default(omit) }}"
     name: "{{ export_vm_as_ovf_vm_name | default(omit) }}"
     uuid: "{{ export_vm_as_ovf_vm_uuid | default(omit) }}"

--- a/tests/integration/targets/vmware_ops_export_vm_as_ovf_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_export_vm_as_ovf_test/tasks/main.yml
@@ -15,7 +15,7 @@
         name: "{{ export_vm_as_ovf_vm_name }}"
         state: poweredoff
         folder: "/{{ vcenter_datacenter }}/vm/e2e-qe"
-        datacenter: "{{ export_vm_as_ovf_datacenter_name }}"
+        datacenter: "{{ export_vm_as_ovf_datacenter }}"
         disk:
           - size_gb: 5
             type: thick

--- a/tests/integration/targets/vmware_ops_export_vm_as_ovf_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_export_vm_as_ovf_test/vars/main.yml
@@ -5,7 +5,7 @@ export_vm_as_ovf_hostname: "{{ vcenter_hostname }}"
 export_vm_as_ovf_username: "{{ vcenter_username }}"
 export_vm_as_ovf_password: "{{ vcenter_password }}"
 export_vm_as_ovf_validate_certs: false
-export_vm_as_ovf_datacenter_name: "{{ vcenter_datacenter }}"
+export_vm_as_ovf_datacenter: "{{ vcenter_datacenter }}"
 
 export_vm_as_ovf_export_dir: /tmp/export_vm_as_ovf
 export_vm_as_ovf_vm_name: "{{ tiny_prefix }}-export-vm-as-ovf-test"


### PR DESCRIPTION
This change is from the testathon feedback.

It includes two issues:
1. The documentation for the export_vm_as_ovf role had duplicate and unused variables defined
2. The role uses a `_name` suffix on the datacenter variable that is inconsistent with other roles.

I updated the docs and changed the variable to match other roles, while keeping the old variable name valid