### PR TITLE
move datacenter out of auth vars for manage_folder

### DIFF
--- a/changelogs/fragments/106-fix-variable-docs-in-manage-folder.yml
+++ b/changelogs/fragments/106-fix-variable-docs-in-manage-folder.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - manage_folder - Fixed the location of variables in docs to match other roles
+  - manage_folder - Updated datacenter var name to match other roles while keeping backwards compat

--- a/roles/manage_folder/README.md
+++ b/roles/manage_folder/README.md
@@ -20,13 +20,14 @@ N/A
 - **manage_folder_validate_certs**
   - Allows connection when SSL certificates are not valid. Set to false when certificates are not trusted.
 
-- **manage_folder_datacenter_name**:
-  - The name of the datacenter in vSphere vCenter which contains the cluster to configure.
-
 - **manage_folder_port**:
   - str or int, The port used to authenticate to the vSphere vCenter that contains the cluster to configure.
 
 ### Other
+- **manage_folder_datacenter**:
+  - The name of the datacenter in vSphere vCenter which contains the cluster to configure.
+  - Aliases: [manage_folder_datacenter]
+
 - **manage_folder_folder_name**:
   - str, required, The name of folder to manage. It can be a single name like `foo` or a path like `foo/bar/buzz`.
 

--- a/roles/manage_folder/README.md
+++ b/roles/manage_folder/README.md
@@ -26,7 +26,7 @@ N/A
 ### Other
 - **manage_folder_datacenter**:
   - The name of the datacenter in vSphere vCenter which contains the cluster to configure.
-  - Aliases: [manage_folder_datacenter]
+  - Aliases: [manage_folder_datacenter_name]
 
 - **manage_folder_folder_name**:
   - str, required, The name of folder to manage. It can be a single name like `foo` or a path like `foo/bar/buzz`.

--- a/roles/manage_folder/tasks/main.yml
+++ b/roles/manage_folder/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Check Mandatory Variables Are Defined
   ansible.builtin.assert:
     that:
-      - manage_folder_datacenter_name is defined
+      - manage_folder_datacenter is defined or manage_folder_datacenter_name is defined
       - manage_folder_folder_name is defined and ((manage_folder_folder_name | length) > 0)
       - manage_folder_hostname is defined
       - manage_folder_username is defined
@@ -14,6 +14,11 @@
   ansible.builtin.fail:
     msg: Folder name should not be absolute. It should be relative to /<datacenter>/<type>
   when: manage_folder_folder_name[0] == '/'
+
+- name: Map Variable Aliases to Documented Names
+  ansible.builtin.set_fact:
+    manage_folder_datacenter: "{{ manage_folder_datacenter_name }}"
+  when: manage_folder_datacenter_name is defined
 
 - name: Manage Full Folder Path
   when: manage_folder_parse_name_as_path

--- a/roles/manage_folder/tasks/manage_path_part.yml
+++ b/roles/manage_folder/tasks/manage_path_part.yml
@@ -8,7 +8,7 @@
     port: "{{ manage_folder_port | default(omit) }}"
     proxy_host: "{{ manage_folder_proxy_host | default(omit) }}"
     proxy_port: "{{ manage_folder_proxy_port | default(omit) }}"
-    datacenter_name: "{{ manage_folder_datacenter_name }}"
+    datacenter_name: "{{ manage_folder_datacenter }}"
     folder_type: "{{ manage_folder_folder_type | default(omit) }}"
     folder_name: "{{ _child }}"
     parent_folder: "{{ _parent or omit }}"

--- a/tests/integration/targets/vmware_ops_manage_folder_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_manage_folder_test/tasks/main.yml
@@ -41,7 +41,7 @@
         hostname: "{{ manage_folder_hostname }}"
         username: "{{ manage_folder_username }}"
         password: "{{ manage_folder_password }}"
-        datacenter: "{{ manage_folder_datacenter_name }}"
+        datacenter: "{{ manage_folder_datacenter }}"
         port: "{{ manage_folder_port }}"
         validate_certs: false
       delegate_to: localhost

--- a/tests/integration/targets/vmware_ops_manage_folder_test/vars.yml
+++ b/tests/integration/targets/vmware_ops_manage_folder_test/vars.yml
@@ -7,6 +7,6 @@ manage_folder_username: "test"
 manage_folder_password: "test"
 manage_folder_validate_certs: false
 manage_folder_port: "8989"
-manage_folder_datacenter_name: DC0
+manage_folder_datacenter: DC0
 folder_types:
   - host

--- a/tests/integration/targets/vmware_ops_manage_folder_test/vars/main.yml
+++ b/tests/integration/targets/vmware_ops_manage_folder_test/vars/main.yml
@@ -7,7 +7,7 @@ manage_folder_username: "{{ vcenter_username }}"
 manage_folder_password: "{{ vcenter_password }}"
 manage_folder_validate_certs: false
 manage_folder_port: "{{ vcenter_port }}"
-manage_folder_datacenter_name: "{{ vcenter_datacenter }}"
+manage_folder_datacenter: "{{ vcenter_datacenter }}"
 folder_types:
   - host
   - vm


### PR DESCRIPTION
This change is from the testathon feedback.

It includes two issues:

1. The documentation for the manage_folder role had the datacenter variable in the wrong section
2. I noticed the datacenter for this role is inconsistent with other roles. So i fixed that too

I updated the docs and changed the variable to match other roles, while keeping the old variable name valid
