### PR TITLE
remove validate certs default for info role

### DIFF
--- a/changelogs/fragments/111-remove-info-validate-certs-default.yml
+++ b/changelogs/fragments/111-remove-info-validate-certs-default.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - info - Remove redundant default value for info_validate_certs so the role is consistent with others

--- a/roles/info/defaults/main.yml
+++ b/roles/info/defaults/main.yml
@@ -2,7 +2,7 @@
 info_hostname: "{{ vmware_ops_collection_hostname }}"
 info_username: "{{ vmware_ops_collection_username }}"
 info_password: "{{ vmware_ops_collection_password }}"
-info_validate_certs: "{{ vmware_ops_collection_validate_certs | default(true) }}"
+info_validate_certs: "{{ vmware_ops_collection_validate_certs }}"
 info_port: "{{ vmware_ops_collection_port }}"
 
 info_expose_outputs_as_variable: true

--- a/roles/info/tasks/appliance_info.yml
+++ b/roles/info/tasks/appliance_info.yml
@@ -4,7 +4,7 @@
     username: "{{ info_username }}"
     password: "{{ info_password }}"
     port: "{{ info_port | d(omit) }}"
-    validate_certs: "{{ info_validate_certs }}"
+    validate_certs: "{{ info_validate_certs | default(omit) }}"
     properties: "{{ info_appliance_gather }}"
   register: __appliance
 

--- a/roles/info/tasks/cluster_info.yml
+++ b/roles/info/tasks/cluster_info.yml
@@ -3,7 +3,7 @@
     vcenter_hostname: "{{ info_hostport }}"
     vcenter_username: "{{ info_username }}"
     vcenter_password: "{{ info_password }}"
-    vcenter_validate_certs: "{{ info_validate_certs }}"
+    vcenter_validate_certs: "{{ info_validate_certs | default(omit) }}"
   register: __clusters
   tags:
     - cluster
@@ -14,7 +14,7 @@
     username: "{{ info_username }}"
     password: "{{ info_password }}"
     port: "{{ info_port | d(omit) }}"
-    validate_certs: "{{ info_validate_certs }}"
+    validate_certs: "{{ info_validate_certs | default(omit) }}"
     cluster_name: "{{ item.name }}"
     schema: vsphere
     properties:

--- a/roles/info/tasks/guest_info.yml
+++ b/roles/info/tasks/guest_info.yml
@@ -4,7 +4,7 @@
     username: "{{ info_username }}"
     password: "{{ info_password }}"
     port: "{{ info_port | d(omit) }}"
-    validate_certs: "{{ info_validate_certs }}"
+    validate_certs: "{{ info_validate_certs | default(omit) }}"
   register: __guests
 
 - name: Write Guest Results To File

--- a/roles/info/tasks/license_info.yml
+++ b/roles/info/tasks/license_info.yml
@@ -4,7 +4,7 @@
     username: "{{ info_username }}"
     password: "{{ info_password }}"
     port: "{{ info_port | d(omit) }}"
-    validate_certs: "{{ info_validate_certs }}"
+    validate_certs: "{{ info_validate_certs | default(omit) }}"
   register: __license
 
 - name: Write License Results To File

--- a/roles/info/tasks/storage_info.yml
+++ b/roles/info/tasks/storage_info.yml
@@ -4,7 +4,7 @@
     username: "{{ info_username }}"
     password: "{{ info_password }}"
     port: "{{ info_port | d(omit) }}"
-    validate_certs: "{{ info_validate_certs }}"
+    validate_certs: "{{ info_validate_certs | default(omit) }}"
   register: __storage_policy
 
 - name: Write Storage Policy Results To File


### PR DESCRIPTION
Removing default value for the `info` role's validate certs option. This value is redundant (the default for the modules inside the role is true anyway) and the other roles in this repo do not specify a default.