### PR TITLE
Bugfix/cluster info outputs

### DIFF
--- a/changelogs/fragments/114-update-cluster-info-test.yml
+++ b/changelogs/fragments/114-update-cluster-info-test.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - info - added test checks to make sure content is returned when requested

--- a/roles/info/tasks/cluster_info.yml
+++ b/roles/info/tasks/cluster_info.yml
@@ -57,10 +57,7 @@
     # it sets the variable even if the block is skipped.
     - name: Map Cluster Info To Correct Variable
       ansible.builtin.set_fact:
-        __a_clusters_info: "{{ __dc_clusters_info }}"
-
-- debug:
-    var: __clusters_info.results
+        __clusters_info: "{{ __dc_clusters_info }}"
 
 - name: Write Cluster Results To File
   when: info_cluster_file

--- a/roles/info/tasks/cluster_info.yml
+++ b/roles/info/tasks/cluster_info.yml
@@ -50,9 +50,14 @@
       loop: "{{ info_datacenters }}"
       loop_control:
         loop_var: _dc_name
-      register: __clusters_info
+      register: __dc_clusters_info
       tags:
         - cluster
+    # If we register the task above directly to __clusters_info,
+    # it sets the variable even if the block is skipped.
+    - name: Map Cluster Info To Correct Variable
+      ansible.builtin.set_fact:
+        __clusters_info: "{{ __dc_clusters_info }}"
 
 - name: Write Cluster Results To File
   when: info_cluster_file

--- a/roles/info/tasks/cluster_info.yml
+++ b/roles/info/tasks/cluster_info.yml
@@ -18,7 +18,7 @@
         password: "{{ info_password }}"
         port: "{{ info_port | d(omit) }}"
         validate_certs: "{{ info_validate_certs | default(omit) }}"
-        cluster: "{{ _cluster_name }}"
+        cluster: "{{ _cluster.name }}"
         schema: vsphere
         properties:
           - name
@@ -26,7 +26,7 @@
           - summary.totalCpu
       loop: "{{ __clusters.value }}"
       loop_control:
-        loop_var: _cluster_name
+        loop_var: _cluster
       register: __clusters_info
       tags:
         - cluster
@@ -57,7 +57,10 @@
     # it sets the variable even if the block is skipped.
     - name: Map Cluster Info To Correct Variable
       ansible.builtin.set_fact:
-        __clusters_info: "{{ __dc_clusters_info }}"
+        __a_clusters_info: "{{ __dc_clusters_info }}"
+
+- debug:
+    var: __clusters_info.results
 
 - name: Write Cluster Results To File
   when: info_cluster_file

--- a/roles/info/tasks/main.yml
+++ b/roles/info/tasks/main.yml
@@ -39,6 +39,6 @@
       license: "{{ __license.licenses | default([]) }}"
       appliance: "{{ __appliance.appliance | default({}) }}"
       guest: "{{ __guests.guests | default([]) }}"
-      cluster: "{{ _clusters_info.results | default([]) | map(attribute='clusters') }}"
+      cluster: "{{ __clusters_info.results | default([]) | map(attribute='clusters') }}"
       storage: "{{ __storage_policy.spbm_profiles | default([]) }}"
   when: info_expose_outputs_as_variable

--- a/tests/integration/targets/vmware_ops_info_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_info_test/tasks/main.yml
@@ -11,3 +11,9 @@
       - vmware_ops_info_outputs.guest is defined
       - vmware_ops_info_outputs.cluster is defined
       - vmware_ops_info_outputs.storage is defined
+
+      - (vmware_ops_info_outputs.appliance | length | bool) == info_appliance
+      - (vmware_ops_info_outputs.license | length | bool) == info_license
+      - (vmware_ops_info_outputs.guest | length | bool) == info_guest
+      - (vmware_ops_info_outputs.cluster | length | bool) == info_cluster
+      - (vmware_ops_info_outputs.storage | length | bool) == info_storage

--- a/tests/integration/targets/vmware_ops_info_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_info_test/tasks/main.yml
@@ -12,8 +12,8 @@
       - vmware_ops_info_outputs.cluster is defined
       - vmware_ops_info_outputs.storage is defined
 
-      - (vmware_ops_info_outputs.appliance | length | bool) == info_appliance
-      - (vmware_ops_info_outputs.license | length | bool) == info_license
-      - (vmware_ops_info_outputs.guest | length | bool) == info_guest
-      - (vmware_ops_info_outputs.cluster | length | bool) == info_cluster
-      - (vmware_ops_info_outputs.storage | length | bool) == info_storage
+      - (vmware_ops_info_outputs.appliance.keys() | length > 0) == info_appliance
+      - (vmware_ops_info_outputs.license | length > 0) == info_license
+      - (vmware_ops_info_outputs.guest | length > 0) == info_guest
+      - (vmware_ops_info_outputs.cluster | length > 0) == info_cluster
+      - (vmware_ops_info_outputs.storage | length > 0) == info_storage

--- a/tests/integration/targets/vmware_ops_info_test/vars.yml
+++ b/tests/integration/targets/vmware_ops_info_test/vars.yml
@@ -5,11 +5,8 @@ vmware_ops_validate_certs: false
 vmware_ops_port: "9000"
 
 prepare_rest_mock_file: "{{ playbook_dir }}/mock.json"
-# workaround till simulator fixed in the next release-
-# check doc in cloud.vmware_ops/roles/cluster_settings
-# for pyvmomi current version limitation
-info_cluster: false
-info_license: true
+info_cluster: true
+info_license: false
 info_appliance: false
 info_guest: false
 info_storage: false


### PR DESCRIPTION
Fixing issue where cluster info var was never set after recent changes. Also making the tests a bit better and checking for actual output instead of just the variable being set