### PR TITLE
Fixed prepare_deploy_esxi_host tasks call in order to run it with AAP

### DIFF
--- a/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_esxi_maintenance_mode_test/tasks/main.yml
@@ -18,8 +18,7 @@
   when: not run_on_simulator
   block:
     - name: Deploy Test ESXi
-      ansible.builtin.import_role:
-        name: prepare_deploy_esxi_host
+      ansible.builtin.import_tasks: ../../prepare_deploy_esxi_host/tasks/main.yml
       vars:
         vcenter_hostname: "{{ vmware_ops_hostname }}"
         vcenter_username: "{{ vmware_ops_username }}"
@@ -110,8 +109,7 @@
         state: absent
       when: deployed_esxi_ips is defined
     - name: Remove Test ESXi
-      ansible.builtin.import_role:
-        name: prepare_deploy_esxi_host
+      ansible.builtin.import_tasks: ../../prepare_deploy_esxi_host/tasks/main.yml
       vars:
         vcenter_hostname: "{{ vmware_ops_hostname }}"
         vcenter_username: "{{ vmware_ops_username }}"

--- a/tests/integration/targets/vmware_ops_vcenter_host_connection_test/tasks/main.yml
+++ b/tests/integration/targets/vmware_ops_vcenter_host_connection_test/tasks/main.yml
@@ -3,8 +3,7 @@
   when: not run_on_simulator
   block:
     - name: Deploy Test ESXi
-      ansible.builtin.import_role:
-        name: prepare_deploy_esxi_host
+      ansible.builtin.import_tasks: ../../prepare_deploy_esxi_host/tasks/main.yml
       vars:
         vcenter_hostname: "{{ vmware_ops_hostname }}"
         vcenter_username: "{{ vmware_ops_username }}"
@@ -98,8 +97,7 @@
         state: absent
       when: deployed_esxi_ips is defined
     - name: Remove Test ESXi
-      ansible.builtin.import_role:
-        name: prepare_deploy_esxi_host
+      ansible.builtin.import_tasks: ../../prepare_deploy_esxi_host/tasks/main.yml
       vars:
         vcenter_hostname: "{{ vmware_ops_hostname }}"
         vcenter_username: "{{ vmware_ops_username }}"


### PR DESCRIPTION
Fixed `prepare_deploy_esxi_host` tasks call in order to run it with AAP.
Previously tests failed with error:
`ERROR! the role 'prepare_deploy_esxi_host' was not found in /runner/project/roles:/runner/requirements_roles:/root/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/runner/project`