### PR TITLE
fix: use community.vmware for standalone ESXi compatibility

### DIFF
--- a/roles/provision_vcenter/tasks/main.yml
+++ b/roles/provision_vcenter/tasks/main.yml
@@ -7,14 +7,18 @@
   ansible.builtin.include_tasks: validate_inputs.yml
 
 - name: Check If vCenter Already Exists
-  vmware.vmware.guest_info:
+  community.vmware.vmware_vm_info:
     hostname: "{{ provision_vcenter_hostname }}"
     username: "{{ provision_vcenter_username }}"
     password: "{{ provision_vcenter_password }}"
     port: "{{ provision_vcenter_port | default(omit) }}"
     validate_certs: "{{ provision_vcenter_validate_certs | default(omit) }}"
-    name: "{{ provision_vcenter_vm_name }}"
-  register: _vcenter_lookup
+  register: _vcenter_vm_lookup
+
+- name: Set vCenter Lookup Result
+  ansible.builtin.set_fact:
+    _vcenter_lookup:
+      guests: "{{ _vcenter_vm_lookup.virtual_machines | default([]) | selectattr('guest_name', 'equalto', provision_vcenter_vm_name) | list }}"
 
 - name: Create Instance From ISO
   when: not _vcenter_lookup.guests


### PR DESCRIPTION
Specifically for provision_vcenter

vmware.vmware.guest_info uses the vSphere REST API session endpoint (com.vmware.cis.session) which only exists on vCenter Server. When deploying to standalone ESXi, the module fails with:

  ApiAccessError: Unknown interface: com.vmware.cis.session

Replace with community.vmware.vmware_vm_info which uses pyvmomi/SOAP and works on both vCenter and standalone ESXi. The role already depends on community.vmware (vmware_guest_powerstate on line 43).

Tested against standalone ESXi 8.0.2 build-23305546.

Regression introduced in commit 498656e (Aug 2024) which replaced community.vmware modules with vmware.vmware certified modules without accounting for standalone ESXi API differences.